### PR TITLE
Term styling and template examples

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -240,12 +240,10 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
     <p class="note">
       JSON Schema resources can comprise subschemas, where portions of a root
       schema document are separately identifiable by a URI-reference that are not
-      absolute and/or contain non-empty fragments.  For example,
-      <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items/definitions/rationalType</code>
-      is a reference to a subschema within the SMPTE JSON Schema resource
-      <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items</code>
-      where the subschema represents the constraints for a JSON structure
-      representing a rational value.
+      absolute and/or contain non-empty fragments. </p>
+      
+    <p class="example">
+      <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items/definitions/rationalType</code> is a reference to a subschema within the SMPTE JSON Schema resource <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items</code> where the subschema represents the constraints for a JSON structure representing a rational value.
     </p>
     
   </section>

--- a/example/index.html
+++ b/example/index.html
@@ -7,28 +7,44 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script src="../smpte.js"></script>
   <link rel="stylesheet" href="../smpte.css" />
+  <!-- Do not edit above this line -->
+  <!-- Start of editable section in header-->
+  <!-- Update only content attributes in each meta element below as needed -->
   <meta itemprop="pubType" content="AG" />
   <meta itemprop="pubNumber" content="XX" />
   <meta itemprop="pubState" content="published" />
   <meta itemprop="pubDateTime" content="20XX-XX-XX" />
+  <!-- update text for title element as needed -->
   <title>HTML Template</title>
+  <!-- End of editable section in header-->
 </head>
 
 <body>
 
-  <section id="sec-foreword" class="unnumbered"></section>
+  <!-- Start of TOC - Do not remove or add anything in this section, generation is automated -->
+  <section id="sec-toc"></section>
+  <!-- End of TOC -->
 
-  <section id="sec-toc" class="unnumbered"></section>
+  <!-- Start of Forward - Do not remove or add anything in this section, generation is automated -->
+  <section id="sec-foreword"></section>
+  <!-- End of Forward -->
 
+  <!-- Start of Scope - Do not remove this section -->
   <section id="sec-scope">
-    <h2>Scope</h2>
-    <p>This Administrative Guideline specifies selected uses of the JavaScript Object Notation (JSON) in SMPTE
-      Engineering Documents.</p>
+    <!-- Add paragraphs in this section as needed for scope -->
+    <p>This Administrative Guideline specifies selected uses of the JavaScript Object Notation (JSON) in SMPTE Engineering Documents.</p>
+
   </section>
+  <!-- End of Scope -->
 
+  <!-- Start of Conformance - Do not remove or add anything in this section, generation is automated -->
   <section id="sec-conformance"></section>
+  <!-- End of Conformance -->
 
+  <!-- Start of Normative references - Do not remove this section -->
   <section id="sec-normative-references">
+
+    <!-- Add `li` sub elements as needed in this section as needed for references. If no Normative references, remove the entire `ul` element. Pre text for this section is auto generated based on `ul` present or not. -->
     <ul>
       <li><cite id="bib-ietf-rfc-3986">IETF RFC 3986</cite>, Uniform Resource
       Identifiers (URI): Generic Syntax, T. Berners-Lee, et al., January 2005. <a>http://www.ietf.org/rfc/rfc3986.txt</a></li>
@@ -39,11 +55,14 @@
       <li><cite id="bib-ietf-rfc-8259">IETF RFC 8259</cite>, The JavaScript
       Object Notation (JSON) Data Interchange Format, T. Bray, <a>http://www.ietf.org/rfc/rfc8259.txt</a></li>
     </ul>
-  </section>
 
-  <section id="sec-terms">
-    <h2>Terms</h2>
-    <p>This section show how to use <code>&lt;dl&gt;</code> for terms, noted by <code>id="sec-terms"</code>, includes abbreviations as <code>&lt;dd class="abbr"&gt;</code>.</p>
+  </section>
+  <!-- End of Normative references -->
+
+  <!-- Start of Terms and definitions - Do not remove this section -->
+  <section id="sec-terms-and-definitions">
+
+    <!-- Add `dt/dd` sub element pairs as needed in this section as needed for references. If no Normative references, remove the entire `dl` element. Pre text for this section is auto generated based on `dl` present or not. -->
     <dl>
       <dt id="group">Group</dt>
       <dd>
@@ -56,10 +75,13 @@
       </dd>
     </dl>
   </section>
+  <!-- End of Terms and definitions -->
+
+  <!-- Start of editable area. Add sections as needed, following the examples below. `id` attribue is required for each section (and subsection) for linking into TOC. Headers are required for labeling each section. Use `h2` element for top level, and `h3`, `h4`, etc. for nested sub sections as needed. For Annexes, add `class="annex"` to the top level section element, as example shows. Numbering is auto generated, including nesting. --> 
 
   <section id="sec-details">
     <h2>Details</h2>
-    <p>This section show how to use <code>&lt;dl&gt;</code> normally in sections that are not <code>id="sec-terms"</code>.</p>
+    <p>This section show how to use <code>&lt;dl&gt;</code> normally in sections that are not <code>id="sec-terms-and-definitions"</code>.</p>
     <dl>
       <dt>Chair</dt>
       <dd>
@@ -345,17 +367,19 @@ are permitted provided that the following conditions are met:
   </section>
 </section>
 
-<section id="sec-bibliographic-references">
+<!-- End of editable sections -->
+
+<!-- Start of Bibliography - Do not remove this section -->
+<section id="sec-bibliography">
+  <!-- Add `li` sub elements as needed in this section as needed for references. If no Bibliographic references, remove the entire `ul` element. Pre text for this section is auto generated based on `ul` present or not. -->
   <ul>
-    <li><cite id="bib-draft-bhutton-json-schema-00">IETF
-    draft-bhutton-json-schema-00</cite>, Wright, A., H. Andrews; B. Hutton, G.
-    Dennis, "JSON Schema: A Media Type for Describing JSON Documents", Work in
-    Progress, December 8, 2020.
-    <a>https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00</a>
-    </li>
+    <li><cite id="bib-draft-bhutton-json-schema-00">IETF draft-bhutton-json-schema-00</cite>, Wright, A., H. Andrews; B. Hutton, G. Dennis, "JSON Schema: A Media Type for Describing JSON Documents", Work in Progress, December 8, 2020.
+    <a>https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00</a></li>
   </ul>
+
 </section>
+<!-- End of Normative references -->
 
+<!-- Do not edit below this line -->
 </body>
-
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -8,10 +8,10 @@
   <script src="../smpte.js"></script>
   <link rel="stylesheet" href="../smpte.css" />
   <meta itemprop="pubType" content="AG" />
-  <meta itemprop="pubNumber" content="25" />
+  <meta itemprop="pubNumber" content="XX" />
   <meta itemprop="pubState" content="published" />
-  <meta itemprop="pubDateTime" content="2022-07-05" />
-  <title>Use of JSON in Engineering Documents</title>
+  <meta itemprop="pubDateTime" content="20XX-XX-XX" />
+  <title>HTML Template</title>
 </head>
 
 <body>
@@ -39,6 +39,37 @@
       <li><cite id="bib-ietf-rfc-8259">IETF RFC 8259</cite>, The JavaScript
       Object Notation (JSON) Data Interchange Format, T. Bray, <a>http://www.ietf.org/rfc/rfc8259.txt</a></li>
     </ul>
+  </section>
+
+  <section id="sec-terms">
+    <h2>Terms</h2>
+    <p>This section show how to use <code>&lt;dl&gt;</code> for terms, noted by <code>id="sec-terms"</code>, includes abbreviations as <code>&lt;dd class="abbr"&gt;</code>.</p>
+    <dl>
+      <dt id="group">Group</dt>
+      <dd>
+        <p>is the Group that authored the document (e.g., TC name, “31FS”)</p>
+      </dd>
+      <dt id="spreadsheet">Spreadsheet</dt>
+      <dd class="abbr">.xlsx</dd>
+      <dd>
+        <p>The Project Group shall decide which spreadsheet format (.xls or .xlsx) to use for each project. The preferred format is .xlsx.</p>
+      </dd>
+    </dl>
+  </section>
+
+  <section id="sec-details">
+    <h2>Details</h2>
+    <p>This section show how to use <code>&lt;dl&gt;</code> normally in sections that are not <code>id="sec-terms"</code>.</p>
+    <dl>
+      <dt>Chair</dt>
+      <dd>
+         <p>Just the name of the person who will be the main contact for the project. No email address – it will be on a public website. Usually the first listed proponent.</p>
+      </dd>
+      <dt>Description</dt>
+      <dd>
+         <p>A short description of the project’s purpose and objectives. This text is aimed at the public who will read it and thus should be able to understand the Project in general terms. There may be extra requirements for this field for the Public CD Process</p>
+      </dd>
+    </dl>
   </section>
 
   <section id="sec-smpte-json-structures">

--- a/example/index.html
+++ b/example/index.html
@@ -64,7 +64,7 @@
 
     <!-- Use the `ul` element to list external documents where Terms are defined (use same logic as referenced docs in the body of the document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `ul` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `ul` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
 
-    <dl id="terms-ext-defs" itemscope="https://www.smpte.org/external-refs">
+    <ul id="terms-ext-defs" itemscope="http://smpte.org/standards/external-definitions">
       <li><a itemprop="external" href="#bib-ietf-rfc-8259"></a></li>
       <li><a itemprop="external" href="#bib-ietf-rfc-7405"></a></li>
     </ul>

--- a/example/index.html
+++ b/example/index.html
@@ -64,7 +64,7 @@
 
     <!-- Use the `p` element to list external documents where Terms are defined (use same logic as referenced docs in the body of hte document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `p` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `p` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
 
-    <p hidden id="terms-ext-defs"><a href="#bib-ietf-rfc-8259"></a> and <a href="#bib-ietf-rfc-7405"></a></p>
+    <p hidden id="terms-ext-defs"><a href="#bib-ietf-rfc-8259"></a>, <a href="#bib-ietf-rfc-7405"></a>,</p>
 
     <dl id="terms-int-defs">
       <dt><dfn>Group</dfn></dt>

--- a/example/index.html
+++ b/example/index.html
@@ -64,9 +64,9 @@
 
     <!-- Use the `ul` element to list external documents where Terms are defined (use same logic as referenced docs in the body of the document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `ul` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `ul` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
 
-    <ul id="terms-ext-defs">
-      <li><a href="#bib-ietf-rfc-8259"></a></li>
-      <li><a href="#bib-ietf-rfc-7405"></a></li>
+    <dl id="terms-ext-defs" itemscope="https://www.smpte.org/external-refs">
+      <li><a itemprop="external" href="#bib-ietf-rfc-8259"></a></li>
+      <li><a itemprop="external" href="#bib-ietf-rfc-7405"></a></li>
     </ul>
 
     <dl id="terms-int-defs">

--- a/example/index.html
+++ b/example/index.html
@@ -62,7 +62,7 @@
   <!-- Start of Terms and definitions - Do not remove this section -->
   <section id="sec-terms-and-definitions">
 
-    <!-- Use the `p` element to list external documents where Terms are defined (use same logic as referenced docs in the body of hte document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `p` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `p` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
+    <!-- Use the `p` element to list external documents where Terms are defined (use same logic as referenced docs in the body of the document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `p` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `p` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
 
     <p hidden id="terms-ext-defs"><a href="#bib-ietf-rfc-8259"></a>, <a href="#bib-ietf-rfc-7405"></a>,</p>
 

--- a/example/index.html
+++ b/example/index.html
@@ -62,16 +62,19 @@
   <!-- Start of Terms and definitions - Do not remove this section -->
   <section id="sec-terms-and-definitions">
 
-    <!-- Add `dt/dd` sub element pairs as needed in this section as needed for references. If no Normative references, remove the entire `dl` element. Pre text for this section is auto generated based on `dl` present or not. -->
-    <dl>
-      <dt id="group">Group</dt>
+    <!-- Use the `p` element to list external documents where Terms are defined (use same logic as referenced docs in the body of hte document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `p` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `p` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
+
+    <p hidden id="terms-ext-defs"><a href="#bib-ietf-rfc-8259"></a> and <a href="#bib-ietf-rfc-7405"></a></p>
+
+    <dl id="terms-int-defs">
+      <dt><dfn>Group</dfn></dt>
       <dd>
-        <p>is the Group that authored the document (e.g., TC name, “31FS”)</p>
+        <p>is the group that authored the document (e.g., TC name, “31FS”)</p>
       </dd>
-      <dt id="spreadsheet">Spreadsheet</dt>
-      <dd class="abbr">.xlsx</dd>
+      <dt><dfn>Spreadsheet</dfn></dt>
+      <dd><abbr title="Spreadsheet">.xlsx</abbr></dd>
       <dd>
-        <p>The Project Group shall decide which spreadsheet format (.xls or .xlsx) to use for each project. The preferred format is .xlsx.</p>
+        <p>The project <a>Group</a> shall decide which spreadsheet format (.xls or .xlsx) to use for each project. The preferred format is .xlsx.</p>
       </dd>
     </dl>
   </section>
@@ -116,8 +119,8 @@
         the Engineering Document.
       </p>
       <p>
-        Each SMPTE JSON structure should be informatively specified by a JSON Schema
-        resource, which may be a SMPTE JSON Schema resource (see section 5), using
+        Each <a>SMPTE JSON structure</a> should be informatively specified by a JSON Schema
+        resource, which may be a <a>SMPTE JSON Schema</a> resource (see <a href="#sec-smpte-json-schema-resources"></a>), using
         the JSON Schema language as specified in <a href="#bib-draft-bhutton-json-schema-00"></a>.
       </p>
     </section>
@@ -125,7 +128,7 @@
   </section>
 
 <section id="sec-smpte-json-schema-resources">
-  <h2>SMPTE JSON Schema resources</h2>
+  <h2><dfn>SMPTE JSON Schema</dfn> resources</h2>
   
   <section id="sec-introduction">
     <h3>Introduction (informative)</h3>
@@ -147,7 +150,7 @@
     <section id="sec-id-keyword">
       <h4><code>$id</code> Keyword</h4>
       
-      <p>A SMPTE JSON Schema resource shall use the <code>$id</code> keyword in the root schema
+      <p>A <a>SMPTE JSON Schema</a> resource shall use the <code>$id</code> keyword in the root schema
       object, thereby providing the canonical URI for the JSON root schema.</p>
     </section>
     
@@ -178,15 +181,15 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
       JSON Schema remain unchanged.</p>
       
       <p class="note">
-        No changes to SMPTE JSON Schema canonical URI are necessary following a Draft
-        Publication ballot since SMPTE JSON Schema canonical URI are constructed
+        No changes to <a>SMPTE JSON Schema</a> canonical URI are necessary following a Draft
+        Publication ballot since <a>SMPTE JSON Schema</a> canonical URI are constructed
         independently of the publication date of the Engineering Document.
       </p>
     </section>
     
     <section id="sec-examples">
       <h4>Examples (informative)</h4>
-      The following is an example SMPTE JSON Schema resource canonical URI:
+      The following is an example <a>SMPTE JSON Schema</a> resource canonical URI:
       
       <pre>https://www.smpte-ra.org/json-schema/456/2021/foo</pre>
       
@@ -213,7 +216,7 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
       <h4>Registration (informative)</h4>
       
       <p>
-        The SMPTE JSON Schema resource canonical URI syntax ensures uniqueness across
+        The <a>SMPTE JSON Schema</a> resource canonical URI syntax ensures uniqueness across
         Engineering Documents, and thus no specific registration steps are required.
       </p>
 
@@ -228,14 +231,14 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
   </section>
   
   <section id="sec-using-a-smpte-json-schema-resource">
-    <h3>Using a SMPTE JSON Schema Resource</h3>
+    <h3>Using a <a>SMPTE JSON Schema</a> Resource</h3>
     
-    <p>A SMPTE JSON Schema resource can be used informatively by an Engineering
+    <p>A <a>SMPTE JSON Schema</a> resource can be used informatively by an Engineering
     Document, either by inclusion or by reference.</p>
     
     <p class="note">The current specification of JSON Schema, though well-supported, is not a
     normatively referenceable document per the Standards Operations Manual (section
-    10 Normative References) and AG-03. Thus, provision of SMPTE JSON Schema
+    10 Normative References) and AG-03. Thus, provision of <a>SMPTE JSON Schema</a>
     resources, at this time, is strictly informative.</p>
   </section>
     
@@ -243,13 +246,13 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
     <h3>Version</h3>
     
     <p>
-      Whenever a SMPTE JSON Schema resource is provided, the Engineering Document
+      Whenever a <a>SMPTE JSON Schema</a> resource is provided, the Engineering Document
       shall provide an informative reference to the JSON Schema language specification
       to which it conforms (e.g., JSON Schema, as shown in the Bibliography).
     </p>
     
     <p>
-      A SMPTE JSON Schema resource shall use the <code>$schema</code> keyword in the root schema
+      A <a>SMPTE JSON Schema</a> resource shall use the <code>$schema</code> keyword in the root schema
       object.
     </p>
     
@@ -265,7 +268,7 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
       absolute and/or contain non-empty fragments. </p>
       
     <p class="example">
-      <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items/definitions/rationalType</code> is a reference to a subschema within the SMPTE JSON Schema resource <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items</code> where the subschema represents the constraints for a JSON structure representing a rational value.
+      <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items/definitions/rationalType</code> is a reference to a subschema within the <a>SMPTE JSON Schema</a> resource <code>https://smpte-ra.org/schemas/2120-2/2021/smpte-tlx-items</code> where the subschema represents the constraints for a JSON structure representing a rational value.
     </p>
     
   </section>
@@ -273,7 +276,7 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
   <section id="sec-keyword-order">
     <h3>Keyword Order</h3>
     
-    <p>The following keywords should appear as the first keywords in any SMPTE JSON Schema resource in this order:</p>
+    <p>The following keywords should appear as the first keywords in any <a>SMPTE JSON Schema</a> resource in this order:</p>
     
     <ul>
       <li><code>$schema,</code> as specified in <a href="#sec-version"></a></li>
@@ -292,7 +295,7 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
     <h3>License</h3>
     
     <p>
-      Any SMPTE JSON structure or SMPTE JSON Schema resource, whether provided within
+      Any <a>SMPTE JSON structure</a> or <a>SMPTE JSON Schema</a> resource, whether provided within
       the prose or as an Additional Element of an Engineering Document, shall be
       licensed according to <a href="#sec-json-document-license"></a>.
     </p>
@@ -304,9 +307,9 @@ STABLEREV = 4(DIGIT) [2(DIGIT)]
   </section>
   
   <section id="sec-cc-license-schema-resources">
-    <h3>Copyright and License in SMPTE JSON Schema resources</h3>
+    <h3>Copyright and License in <a>SMPTE JSON Schema</a> resources</h3>
     
-    Any SMPTE JSON Schema resource shall include the copyright and license
+    Any <a>SMPTE JSON Schema</a> resource shall include the copyright and license
     provided in <a href="#sec-json-document-license"></a> in the form of the
     <code>$comment</code> element specified in <a href="#sec-license-element"></a>.
   </section>

--- a/example/index.html
+++ b/example/index.html
@@ -62,19 +62,20 @@
   <!-- Start of Terms and definitions - Do not remove this section -->
   <section id="sec-terms-and-definitions">
 
-    <!-- Use the `p` element to list external documents where Terms are defined (use same logic as referenced docs in the body of the document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `p` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `p` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
+    <!-- Use the `ul` element to list external documents where Terms are defined (use same logic as referenced docs in the body of the document as example shows). Add `dt/dd` sub element pairs as needed for Terms to be defined internally in this document. Remove either the `ul` if no external Terms, or `dl` if no internally defined Terms. If no Terms needed to be defined at all, remove the both `ul` and `dl` elements. Pre text for this section is auto generated based on what elements are present. -->
 
-    <p hidden id="terms-ext-defs"><a href="#bib-ietf-rfc-8259"></a>, <a href="#bib-ietf-rfc-7405"></a>,</p>
+    <ul id="terms-ext-defs">
+      <li><a href="#bib-ietf-rfc-8259"></a></li>
+      <li><a href="#bib-ietf-rfc-7405"></a></li>
+    </ul>
 
     <dl id="terms-int-defs">
       <dt><dfn>Group</dfn></dt>
-      <dd>
-        <p>is the group that authored the document (e.g., TC name, “31FS”)</p>
+      <dd>is the group that authored the document (e.g., TC name, “31FS”)
       </dd>
       <dt><dfn>Spreadsheet</dfn></dt>
       <dd><abbr title="Spreadsheet">.xlsx</abbr></dd>
-      <dd>
-        <p>The project <a>Group</a> shall decide which spreadsheet format (.xls or .xlsx) to use for each project. The preferred format is .xlsx.</p>
+      <dd>The project <a>Group</a> shall decide which spreadsheet format (.xls or .xlsx) to use for each project. The preferred format is .xlsx.
       </dd>
     </dl>
   </section>
@@ -87,12 +88,10 @@
     <p>This section show how to use <code>&lt;dl&gt;</code> normally in sections that are not <code>id="sec-terms-and-definitions"</code>.</p>
     <dl>
       <dt>Chair</dt>
-      <dd>
-         <p>Just the name of the person who will be the main contact for the project. No email address – it will be on a public website. Usually the first listed proponent.</p>
+      <dd>Just the name of the person who will be the main contact for the project. No email address – it will be on a public website. Usually the first listed proponent.
       </dd>
       <dt>Description</dt>
-      <dd>
-         <p>A short description of the project’s purpose and objectives. This text is aimed at the public who will read it and thus should be able to understand the Project in general terms. There may be extra requirements for this field for the Public CD Process</p>
+      <dd>A short description of the project’s purpose and objectives. This text is aimed at the public who will read it and thus should be able to understand the Project in general terms. There may be extra requirements for this field for the Public CD Process
       </dd>
     </dl>
   </section>

--- a/smpte.css
+++ b/smpte.css
@@ -148,6 +148,16 @@ dd.abbr {
   counter-increment: notes-counter;
 }
 
+/* example */
+
+.example {
+  font-size: 0.9rem;
+}
+
+.example:before {
+  content: "EXAMPLE: ";
+}
+
 /* table of contents */
 
 section#sec-toc ol {

--- a/smpte.css
+++ b/smpte.css
@@ -246,23 +246,13 @@ figure {
 
 /* references */
 
-#sec-bibliography ul {
+#sec-bibliography ul, #sec-normative-references ul {
   list-style-type: none;
   margin-top: 1rem;
   padding: 0;
 }
 
-#sec-bibliography li {
-  margin-top: 1rem;
-}
-
-#sec-normative-references ul {
-  list-style-type: none;
-  margin-top: 1rem;
-  padding: 0;
-}
-
-#sec-normative-references li {
+#sec-bibliography li, #sec-normative-references li {
   margin-top: 1rem;
 }
 
@@ -273,12 +263,7 @@ figure {
   white-space: nowrap;
 }
 
-#sec-normative-references .ext-ref::before {
-  white-space: pre;
-  content: '\A';
-}
-
-#sec-bibliography .ext-ref::before {
+#sec-normative-references .ext-ref::before, #sec-bibliography .ext-ref::before {
   white-space: pre;
   content: '\A';
 }

--- a/smpte.css
+++ b/smpte.css
@@ -131,6 +131,11 @@ dt {
   white-space: pre;
 }
 
+#sec-terms-and-definitions abbr {
+  margin-top: 1em;
+  font-weight: bold;
+}
+
 dd.abbr {
   margin-top: 0em;
   font-weight: bold;
@@ -266,6 +271,11 @@ figure {
 .ext-ref {
   word-break: keep-all;
   white-space: nowrap;
+}
+
+.dfn-ref {
+    text-decoration: underline blue dotted;
+    color: black;
 }
 
 /* code */

--- a/smpte.css
+++ b/smpte.css
@@ -46,7 +46,7 @@ h1 {
   font-style: italic;
 }
 
-#sec-front-matter #smpte-logo {
+#smpte-logo {
   float: right;
   width: 250px;
   margin: 1rem;
@@ -117,7 +117,7 @@ section.annex > h2 span.label {
 
 /* terms and definitions */
 
-#sec-terms dd {
+#sec-terms-and-definitions dd {
   margin-left: 0;
 }
 
@@ -126,7 +126,7 @@ dt {
   font-weight: bold;
 }
 
-#sec-terms dt .label::after {
+#sec-terms-and-definitions dt .label::after {
   content: "\A";
   white-space: pre;
 }
@@ -160,12 +160,15 @@ dd.abbr {
 
 /* table of contents */
 
-section#sec-toc ol {
+section#sec-toc ul {
   list-style-type: none;
-  padding: 0;
+  padding-inline-start: 2ch;
   margin: 0.25rem 0 0.25rem 0;
 }
 
+section#sec-toc li {
+
+}
 
 section#sec-toc span.heading-number {
   display: inline-block;
@@ -238,12 +241,13 @@ figure {
 
 /* references */
 
-#sec-bibliographic-references ul {
+#sec-bibliography ul {
   list-style-type: none;
+  margin-top: 1rem;
   padding: 0;
 }
 
-#sec-bibliographic-references li {
+#sec-bibliography li {
   margin-top: 1rem;
 }
 

--- a/smpte.css
+++ b/smpte.css
@@ -165,7 +165,7 @@ dd.abbr {
 
 /* table of contents */
 
-section#sec-toc ul {
+section#sec-toc ol {
   list-style-type: none;
   padding-inline-start: 2ch;
   margin: 0.25rem 0 0.25rem 0;

--- a/smpte.css
+++ b/smpte.css
@@ -121,7 +121,7 @@ section.annex > h2 span.label {
   margin-left: 0;
 }
 
-#sec-terms dt {
+dt {
   margin-top: 1em;
   font-weight: bold;
 }
@@ -129,6 +129,11 @@ section.annex > h2 span.label {
 #sec-terms dt .label::after {
   content: "\A";
   white-space: pre;
+}
+
+dd.abbr {
+  margin-top: 0em;
+  font-weight: bold;
 }
 
 /* note */

--- a/smpte.css
+++ b/smpte.css
@@ -273,6 +273,16 @@ figure {
   white-space: nowrap;
 }
 
+#sec-normative-references .ext-ref::before {
+  white-space: pre;
+  content: '\A';
+}
+
+#sec-bibliography .ext-ref::before {
+  white-space: pre;
+  content: '\A';
+}
+
 .dfn-ref {
     text-decoration: underline blue dotted;
     color: black;

--- a/smpte.js
+++ b/smpte.js
@@ -265,8 +265,6 @@ function insertTermsanddefinitions(docMetadata) {
       p.innerHTML = `For the purposes of this document, the terms and definitions given in ${extList_text} and the following apply:`
     }
 
-
-    // will need to add functionality for external definteddterms
   } else {
     console.log("neither exists")
     p.innerHTML = `No terms and definitions are listed in this document.` 

--- a/smpte.js
+++ b/smpte.js
@@ -251,10 +251,25 @@ function insertTermsanddefinitions(docMetadata) {
   const p = document.createElement("p");
 
   if (sec.childElementCount !== 0) {
-    p.innerHTML = `For the purposes of this document, the following terms and definitions apply.`
+    
+    let defList = document.getElementById("terms-int-defs")
+    let extList = document.getElementById("terms-ext-defs")
+
+    if (extList === null && defList !== null) {
+      p.innerHTML = `For the purposes of this document, the following terms and definitions apply:`
+    } else if (extList !== null && defList === null) {
+      let extList_text = extList.innerHTML
+      p.innerHTML = `For the purposes of this document, the terms and definitions given in ${extList_text} apply.`
+    } else if (extList !== null && defList !== null) {
+      let extList_text = extList.innerHTML
+      p.innerHTML = `For the purposes of this document, the terms and definitions given in ${extList_text} and the following apply:`
+    }
+
+
     // will need to add functionality for external definteddterms
   } else {
-    p.innerHTML = `No terms and definitions are listed in this document.`
+    console.log("neither exists")
+    p.innerHTML = `No terms and definitions are listed in this document.` 
   }
 
   sec.insertBefore(p, sec.firstChild);
@@ -441,7 +456,7 @@ function numberSections(element, curHeadingNumber) {
       numText += headingCounter.toString();
       headingCounter++;
       headingNum.innerText = numText;
-
+      
       headingLabel.appendChild(headingNum);
       headingLabel.appendChild(document.createTextNode(" "));
     }
@@ -617,6 +632,7 @@ function resolveLinks(docMetadata) {
           logEvent(`Unresolved link: ${term}`);
         } else {
           anchor.href = "#" + definitions.get(term).id;
+          anchor.classList.add("dfn-ref");
         }
 
       }

--- a/smpte.js
+++ b/smpte.js
@@ -102,7 +102,7 @@ function insertFrontMatter(docMetadata) {
   sec = document.createElement("section");
   sec.className = "unnumbered";
   sec.id = FRONT_MATTER_ID;
-  sec.innerHTML = `<div class="toc-ignore" id="doc-designator" itemtype="http://purl.org/dc/elements/1.1/">
+  sec.innerHTML = `<div id="doc-designator" itemtype="http://purl.org/dc/elements/1.1/">
     <span itemprop="publisher">SMPTE</span> <span id="doc-type">${docMetadata.pubType}</span> <span id="doc-number">${docMetadata.pubNumber}</span></div>
     <img id="smpte-logo" src="${resolveScriptRelativePath("smpte-logo.png")}" />
     <div id="long-doc-type">${longDoctype}</div>
@@ -126,18 +126,14 @@ function insertTOC(docMetadata) {
       if (subSection.localName !== "section")
         continue;
 
-      if (!subSection.hasAttribute("id"))
+      const secId = subSection.getAttribute("id")
+
+      if (!secId || ['sec-front-matter', 'sec-toc'].includes(secId))
         continue;
 
       const heading = subSection.firstElementChild;
 
       if (!heading)
-        continue;
-
-      const headingNumber = subSection.querySelector(".heading-number");
-      const tocIgnore = subSection.querySelector(".toc-ignore")
-
-      if (!headingNumber && tocIgnore)
         continue;
 
       subSections.push(subSection);
@@ -179,7 +175,7 @@ function insertTOC(docMetadata) {
 
   const h2 = document.createElement("h2");
   h2.innerText = "Table of contents";
-  h2.className = "unnumbered toc-ignore";
+  toc.className = "unnumbered";
 
   toc.appendChild(h2);
 
@@ -242,7 +238,7 @@ function insertNormativeReferences(docMetadata) {
   h2.innerText = "Normative references";
 }
 
-function insertTermsanddefinitions(docMetadata) {
+function insertTermsAndDefinitions(docMetadata) {
   const sec = document.getElementById("sec-terms-and-definitions");
 
   if (sec === null)
@@ -259,10 +255,10 @@ function insertTermsanddefinitions(docMetadata) {
       p.innerHTML = `For the purposes of this document, the following terms and definitions apply:`
     } else if (extList !== null && defList === null) {
       let extList_text = extList.innerHTML
-      p.innerHTML = `For the purposes of this document, the terms and definitions given in ${extList_text} apply.`
+      p.innerHTML = `For the purposes of this document, the terms and definitions given in the following documents apply:`
     } else if (extList !== null && defList !== null) {
       let extList_text = extList.innerHTML
-      p.innerHTML = `For the purposes of this document, the terms and definitions given in ${extList_text} and the following apply:`
+      p.innerHTML = `For the purposes of this document, the terms and definitions given in the following documents and the additional terms and definitions apply:`
     }
 
   } else {
@@ -690,7 +686,7 @@ function render() {
   insertConformance(docMetadata);
   insertScope(docMetadata);
   insertNormativeReferences(docMetadata);
-  insertTermsanddefinitions(docMetadata);
+  insertTermsAndDefinitions(docMetadata);
   insertBibliography(docMetadata);
   numberSections(document.body, "");
   numberTables();

--- a/smpte.js
+++ b/smpte.js
@@ -141,7 +141,7 @@ function insertTOC(docMetadata) {
 
     if (subSections.length > 0) {
 
-      const tocItem = document.createElement("ul");
+      const tocItem = document.createElement("ol");
 
       for (const subSection of subSections) {
         let sectionRef = document.createElement("a");


### PR DESCRIPTION
- updated style and example for terms section and other `dl` usage for non-terms section
- added examples to the template index
- section numbering not yet addressed for term, nor any linking for term, `dfn`, or `abbr`