### PR TITLE
Add missing pre-text for no Bibligraphic references

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -371,16 +371,14 @@ are permitted provided that the following conditions are met:
 
 <!-- End of editable sections -->
 
-<!-- Start of Bibliography - Do not remove this section -->
+<!-- Start of Bibliography - ONLY use if infomative references are present - If no Bibliographic references, remove the entire section. -->
 <section id="sec-bibliography">
-  <!-- Add `li` sub elements as needed in this section as needed for references. If no Bibliographic references, remove the entire `ul` element. Pre text for this section is auto generated based on `ul` present or not. -->
   <ul>
     <li><cite id="bib-draft-bhutton-json-schema-00">IETF draft-bhutton-json-schema-00</cite>, Wright, A., H. Andrews; B. Hutton, G. Dennis, "JSON Schema: A Media Type for Describing JSON Documents", Work in Progress, December 8, 2020.
     <a>https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00</a></li>
   </ul>
-
 </section>
-<!-- End of Normative references -->
+<!-- End of Bibliography -->
 
 <!-- Do not edit below this line -->
 </body>

--- a/smpte.js
+++ b/smpte.js
@@ -290,15 +290,11 @@ function insertBibliography(docMetadata) {
   if (sec === null)
     return;
 
-  sec.classList.add("unnumbered");
-
-  const p = document.createElement("p");
-
   if (sec.childElementCount === 0) {
-    p.innerHTML = `There are no bibliographic references in this document.`
-  } 
-  
-  sec.insertBefore(p, sec.firstChild);
+    logEvent(`No informational references listed, Bibliography section must be removed`)
+  }
+
+  sec.classList.add("unnumbered");
 
   let h2 = sec.getElementsByTagName("h2");
 

--- a/smpte.js
+++ b/smpte.js
@@ -292,6 +292,14 @@ function insertBibliography(docMetadata) {
 
   sec.classList.add("unnumbered");
 
+  const p = document.createElement("p");
+
+  if (sec.childElementCount === 0) {
+    p.innerHTML = `There are no bibliographic references in this document.`
+  } 
+  
+  sec.insertBefore(p, sec.firstChild);
+
   let h2 = sec.getElementsByTagName("h2");
 
   if (h2.length == 0) {


### PR DESCRIPTION
Missed adding pre-text to Bibliography when no references are present, as per https://github.com/SMPTE/html-pub/issues/30. 