### PR TITLE
Clarify code usage

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -1062,7 +1062,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
           <li>namespaces (i.e. <code>http://www.smpte-ra.org/schemas/428-7/2014/DCST</code>)</li>
           <li>short code snippets, e.g. <code>&lt;meta charset=&quot;utf-8&quot; /&gt;</code> or <code>int i = 3;</code></li>
      
-          <li>element or attribute values (i.e. <code>true</code> or <code>00:00:04:ZeroE</code>)</li>
+          <li>literal values, e.g., <code>true</code> or <code>00:00:04:ZeroE</code></li>
           <li>string value patterns (i.e. <code>YYYY-MM-DD</code>)</li>
         </ul>
 

--- a/doc/main.html
+++ b/doc/main.html
@@ -1063,7 +1063,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
           <li>short code snippets, e.g. <code>&lt;meta charset=&quot;utf-8&quot; /&gt;</code> or <code>int i = 3;</code></li>
      
           <li>literal values, e.g., <code>true</code> or <code>00:00:04:ZeroE</code></li>
-          <li>string value patterns (i.e. <code>YYYY-MM-DD</code>)</li>
+          <li>regular expressions or match pattern, e.g., <code>YYYY-MM-DD</code></li>
         </ul>
 
         <p class="note">

--- a/doc/main.html
+++ b/doc/main.html
@@ -1051,6 +1051,34 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
     
       </section>
       
+      <section id="sec-code-element-usage">
+        <h4><code>code</code> HTML Element Usage</h4>
+        <p>
+          The <code>code</code> HTML element should be used inline to wrap the following in body text and headers:
+        </p>
+        <ul>
+          <li>script names (i.e. <code>smpte.js</code>)</li>
+          <li>element names (i.e. <code>head</code>)</li>
+          <li>namespaces (i.e. <code>http://www.smpte-ra.org/schemas/428-7/2014/DCST</code>)</li>
+          <li>elements with attributes/values pairs or values (i.e. <code>&lt;meta charset=&quot;utf-8&quot; /&gt;</code> or <code>&lt;a&gt;term&lt;/a&gt;</code></li>
+          <li>attributes/values pairs (i.e. <code>charset=&quot;utf-8&quot;</code>)</li>
+          <li>element or attribute values (i.e. <code>true</code> or <code>00:00:04:ZeroE</code>)</li>
+          <li>string value patterns (i.e. <code>YYYY-MM-DD</code>)</li>
+        </ul>
+
+        <p class="note">
+          As seen above, namespaces should be wrapped with <code>code</code> and should not include an <code>a</code> element, as they are not meant to be links. 
+        </p>
+
+        <div class="example">
+          <pre>
+This is an &lt;code&gt;element&lt;/code&gt; that is rendered with the &lt;code&gt;code&lt;/code&gt; HTML element. 
+</pre>
+          <p>results in:</p>
+          <p>This is an <code>element</code> that is rendered with the <code>code</code> HTML element.</p>
+        </div>
+    
+      </section>
 
     </section>
   

--- a/doc/main.html
+++ b/doc/main.html
@@ -1054,7 +1054,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
       <section id="sec-code-element-usage">
         <h4>Inline code fragments</h4>
         <p>
-          The <code>code</code> HTML element should be used inline to wrap the following in body text and headers:
+          Inline code fragments  should be wrapped in a <code>code</code> element. A code fragment is  text that is intended to be used verbatim in computer code, including command line code, including:
         </p>
         <ul>
           <li>script names (i.e. <code>smpte.js</code>)</li>

--- a/doc/main.html
+++ b/doc/main.html
@@ -1061,7 +1061,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
           <li>element names (i.e. <code>head</code>)</li>
           <li>namespaces (i.e. <code>http://www.smpte-ra.org/schemas/428-7/2014/DCST</code>)</li>
           <li>short code snippets, e.g. <code>&lt;meta charset=&quot;utf-8&quot; /&gt;</code> or <code>int i = 3;</code></li>
-          <li>attributes/values pairs (i.e. <code>charset=&quot;utf-8&quot;</code>)</li>
+     
           <li>element or attribute values (i.e. <code>true</code> or <code>00:00:04:ZeroE</code>)</li>
           <li>string value patterns (i.e. <code>YYYY-MM-DD</code>)</li>
         </ul>

--- a/doc/main.html
+++ b/doc/main.html
@@ -1060,7 +1060,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
           <li>script names (i.e. <code>smpte.js</code>)</li>
           <li>element names (i.e. <code>head</code>)</li>
           <li>namespaces (i.e. <code>http://www.smpte-ra.org/schemas/428-7/2014/DCST</code>)</li>
-          <li>elements with attributes/values pairs or values (i.e. <code>&lt;meta charset=&quot;utf-8&quot; /&gt;</code> or <code>&lt;a&gt;term&lt;/a&gt;</code></li>
+          <li>short code snippets, e.g. <code>&lt;meta charset=&quot;utf-8&quot; /&gt;</code> or <code>int i = 3;</code></li>
           <li>attributes/values pairs (i.e. <code>charset=&quot;utf-8&quot;</code>)</li>
           <li>element or attribute values (i.e. <code>true</code> or <code>00:00:04:ZeroE</code>)</li>
           <li>string value patterns (i.e. <code>YYYY-MM-DD</code>)</li>

--- a/doc/main.html
+++ b/doc/main.html
@@ -1067,7 +1067,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
         </ul>
 
         <p class="note">
-          As seen above, namespaces should be wrapped with <code>code</code> and should not include an <code>a</code> element, as they are not meant to be links. 
+          Namespaces are wrapped with a <code>code</code> element and not with an <code>a</code> element since they do not necessarily resolve to a resource. 
         </p>
 
         <div class="example">

--- a/doc/main.html
+++ b/doc/main.html
@@ -1052,7 +1052,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
       </section>
       
       <section id="sec-code-element-usage">
-        <h4><code>code</code> HTML Element Usage</h4>
+        <h4>Inline code fragments</h4>
         <p>
           The <code>code</code> HTML element should be used inline to wrap the following in body text and headers:
         </p>


### PR DESCRIPTION
Update new section for `<code>` usage guidelines. 