### PR TITLE
7.4.16 Formulae, Paragraph preceding EXAMPLE 2, Sentence 1: Update main.html to fix typo

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -1173,7 +1173,7 @@ One needs to evaluate &lt;math&gt;&lt;mrow&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;=&
           <mi>b</mi><mi>x</mi><mo>+</mo><mi>c</mi></mrow></math> to find the position.</p>
         </div>
 
-        <p>A block formula are specified by wrapping a single <code>math</code> element whose <code>display</code> attribute is
+        <p>A block formula is specified by wrapping a single <code>math</code> element whose <code>display</code> attribute is
         <code>"block"</code> in a <code>div</code> element whose class is <code>formula</code> and whose <code>id</code> attribute
         starts with <code>eq-</code>. Block formulae are numbered and can be referenced: see, for example, <a href="#eq-1"></a>.</p>
 


### PR DESCRIPTION
Fixed typo.

Original: "A block formula are specified..."

Corrected: "A block formula is specified..."