### PR TITLE
Fix CI fails on releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
           AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
           CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_REF_NAME: ${{env.GITHUB_REF_NAME}}
 
       - name: Build and deploy document (HTML Pub repo)
         uses: ./workflows
@@ -66,3 +67,4 @@ jobs:
           AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
           CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_REF_NAME: ${{env.GITHUB_REF_NAME}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,6 @@ jobs:
           AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
           CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GITHUB_REF_NAME: ${{env.GITHUB_REF_NAME}}
 
       - name: Build and deploy document (HTML Pub repo)
         uses: ./workflows
@@ -67,4 +66,3 @@ jobs:
           AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
           CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GITHUB_REF_NAME: ${{env.GITHUB_REF_NAME}}

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -11,8 +11,6 @@ inputs:
     required: true
   GITHUB_TOKEN:
     required: true
-  GITHUB_REF_NAME:
-    required: true
 
 runs:
   using: "composite"
@@ -67,9 +65,7 @@ runs:
     - name: Upload artifacts to the release
       if: github.event_name == 'release'
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
-        gh release upload ${{ inputs.GITHUB_REF_NAME }} ${{ steps.build.outputs.LIBRARY_ZIP }}
-        gh release upload ${{ inputs.GITHUB_REF_NAME }} ${{ steps.build.outputs.REVIEW_ZIP }}
-        gh release edit ${{ inputs.GITHUB_REF_NAME }} --notes-file ${{ steps.build.outputs.PUB_LINKS }}
+        gh release upload $GITHUB_REF_NAME ${{ steps.build.outputs.LIBRARY_ZIP }}
+        gh release upload $GITHUB_REF_NAME ${{ steps.build.outputs.REVIEW_ZIP }}
+        gh release edit $GITHUB_REF_NAME --notes-file ${{ steps.build.outputs.PUB_LINKS }}

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -65,7 +65,9 @@ runs:
     - name: Upload artifacts to the release
       if: github.event_name == 'release'
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
-        gh release upload $GITHUB_REF_NAME ${{ steps.build.outputs.LIBRARY_ZIP }}
-        gh release upload $GITHUB_REF_NAME ${{ steps.build.outputs.REVIEW_ZIP }}
-        gh release edit $GITHUB_REF_NAME --notes-file ${{ steps.build.outputs.PUB_LINKS }}
+        gh release upload ${{ env.GITHUB_REF_NAME }} ${{ steps.build.outputs.LIBRARY_ZIP }}
+        gh release upload ${{ env.GITHUB_REF_NAME }} ${{ steps.build.outputs.REVIEW_ZIP }}
+        gh release edit ${{ env.GITHUB_REF_NAME }} --notes-file ${{ steps.build.outputs.PUB_LINKS }}

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   GITHUB_TOKEN:
     required: true
+  GITHUB_REF_NAME:
+    required: true
 
 runs:
   using: "composite"
@@ -68,6 +70,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
-        gh release upload "$GITHUB_REF_NAME" ${{ steps.build.outputs.LIBRARY_ZIP }}
-        gh release upload "$GITHUB_REF_NAME" ${{ steps.build.outputs.REVIEW_ZIP }}
-        gh release edit "$GITHUB_REF_NAME" --notes-file ${{ steps.build.outputs.PUB_LINKS }}
+        gh release upload ${{ inputs.GITHUB_REF_NAME }} ${{ steps.build.outputs.LIBRARY_ZIP }}
+        gh release upload ${{ inputs.GITHUB_REF_NAME }} ${{ steps.build.outputs.REVIEW_ZIP }}
+        gh release edit ${{ inputs.GITHUB_REF_NAME }} --notes-file ${{ steps.build.outputs.PUB_LINKS }}

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -68,6 +68,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
-        gh release upload ${{ env.GITHUB_REF_NAME }} ${{ steps.build.outputs.LIBRARY_ZIP }}
-        gh release upload ${{ env.GITHUB_REF_NAME }} ${{ steps.build.outputs.REVIEW_ZIP }}
-        gh release edit ${{ env.GITHUB_REF_NAME }} --notes-file ${{ steps.build.outputs.PUB_LINKS }}
+        gh release upload ${{ github.event.release.tag_name }} ${{ steps.build.outputs.LIBRARY_ZIP }}
+        gh release upload ${{ github.event.release.tag_name }} ${{ steps.build.outputs.REVIEW_ZIP }}
+        gh release edit ${{ github.event.release.tag_name }} --notes-file ${{ steps.build.outputs.PUB_LINKS }}


### PR DESCRIPTION
GitHub broke `$GITHUB_REF_NAME` on release triggers.