### PR TITLE
Pin adm-zip version to prevent breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-iam": "3.525.0",
         "@aws-sdk/client-s3": "3.525.0",
-        "adm-zip": "^0.5.10",
+        "adm-zip": "0.5.10",
         "jsdom": "^20.0.3",
         "pagedjs-cli": "0.4.3",
         "puppeteer": "19.7.5"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@aws-sdk/client-iam": "3.525.0",
     "@aws-sdk/client-s3": "3.525.0",
-    "adm-zip": "^0.5.10",
+    "adm-zip": "0.5.10",
     "jsdom": "^20.0.3",
     "pagedjs-cli": "0.4.3",
     "puppeteer": "19.7.5"


### PR DESCRIPTION
Pin adm-zip version to avoid fatal errors such as this seen on a recent SMPTE HTML doc repo GitHub Actions workflow:
```
TypeError: val.getFullYear is not a function
    at Utils.fromDate2DOS (/home/runner/work/st2067-206-private/st2067-206-private/node_modules/adm-zip/util/utils.js:328:13)
    at set time [as time] (/home/runner/work/st2067-206-private/st2067-206-private/node_modules/adm-zip/headers/entryHeader.js:101:34)
    at makeLibraryZip (file:///home/runner/work/st2067-206-private/st2067-206-private/tooling/scripts/build.mjs:476:23)
    at main (file:///home/runner/work/st2067-206-private/st2067-206-private/tooling/scripts/build.mjs:774:37)
```
which is caused by:
https://github.com/cthackers/adm-zip/issues/539

(It looks like other breaking changes have been reported with adm-zip in recent releases)