### PR TITLE
Update conformance for EGs

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -492,7 +492,7 @@
 </pre>
         </div>
 
-        <p>This section is prohibited when the document is an administrative guideline, operations manual or engineering guideline.</p>
+        <p>This section is prohibited unless the document is a Standard or Recommended Practice.</p>
 
       </section>
 

--- a/doc/main.html
+++ b/doc/main.html
@@ -492,7 +492,7 @@
 </pre>
         </div>
 
-        <p class="note">This section and additional text is not allowed for AG, OM, and EG docs.</p>
+        <p>This section is prohibited when the document is an administrative guideline, operations manual or engineering guideline.</p>
 
       </section>
 

--- a/doc/main.html
+++ b/doc/main.html
@@ -491,6 +491,9 @@
 &lt;/section&gt;
 </pre>
         </div>
+
+        <p class="note">This section and additional text is not allowed for AG, OM, and EG docs.</p>
+
       </section>
 
       <section id="sec-norm-refs-section">

--- a/smpte.js
+++ b/smpte.js
@@ -612,8 +612,7 @@ function insertConformance(docMetadata) {
     return;
   }
 
-  if (docMetadata.pubType == smpte.EG_PUBTYPE) {
-    if (sec !== null)
+  if ((docMetadata.pubType == smpte.EG_PUBTYPE) && (sec !== null)) {
       logger_.error("EG must not contain a Conformance section.");
   }
 
@@ -637,7 +636,7 @@ function insertConformance(docMetadata) {
 
     } else {
 
-      implConformance = sec.innerText;
+      implConformance = sec.innerHTML;
 
     }
 
@@ -696,18 +695,22 @@ function insertConformance(docMetadata) {
     
     const sections = document.querySelectorAll('section');
     sections.forEach((element) => {
-      let id = element.id;
-      if ((id !== "sec-front-matter") && (id !== "sec-foreword") && (id !== "sec-conformance")) {
-        if (element.innerText.toLowerCase().includes("shall")) {
-          logger_.error(`EG must not contain Conformance Notation - "shall" found`, element);
-        }
-        if (element.innerText.toLowerCase().includes("should")) {
-          logger_.error(`EG must not contain Conformance Notation - "should" found`, element);
-        }
-        if (element.innerText.toLowerCase().includes("may")) {
-          logger_.error(`EG must not contain Conformance Notation - "may" found`, element);
-        }
+   
+      const id = element.id;
+
+      if (id === "sec-front-matter" || id === "sec-foreword" || id === "sec-conformance")
+        return;
+      
+      if (element.innerText.toLowerCase().includes("shall")) {
+        logger_.error(`EG must not contain Conformance Notation - "shall" found`, element);
       }
+      if (element.innerText.toLowerCase().includes("should")) {
+        logger_.error(`EG must not contain Conformance Notation - "should" found`, element);
+      }
+      if (element.innerText.toLowerCase().includes("may")) {
+        logger_.error(`EG must not contain Conformance Notation - "may" found`, element);
+      }
+    
     });
   }
 

--- a/smpte.js
+++ b/smpte.js
@@ -698,13 +698,13 @@ function insertConformance(docMetadata) {
     sections.forEach((element) => {
       let id = element.id;
       if ((id !== "sec-front-matter") && (id !== "sec-foreword") && (id !== "sec-conformance")) {
-        if (element.innerText.includes("shall")) {
+        if (element.innerText.toLowerCase().includes("shall")) {
           logger_.error(`EG must not contain Conformance Notation - "shall" found`, element);
         }
-        if (element.innerText.includes("should")) {
+        if (element.innerText.toLowerCase().includes("should")) {
           logger_.error(`EG must not contain Conformance Notation - "should" found`, element);
         }
-        if (element.innerText.includes("may")) {
+        if (element.innerText.toLowerCase().includes("may")) {
           logger_.error(`EG must not contain Conformance Notation - "may" found`, element);
         }
       }

--- a/smpte.js
+++ b/smpte.js
@@ -612,6 +612,11 @@ function insertConformance(docMetadata) {
     return;
   }
 
+  if (docMetadata.pubType == smpte.EG_PUBTYPE) {
+    if (sec !== null)
+      logger_.error("EG must not contain a Conformance section.");
+  }
+
   if (sec === null) {
     sec = document.createElement("section");
     sec.id = SMPTE_CONFORMANCE_ID;
@@ -632,7 +637,7 @@ function insertConformance(docMetadata) {
 
     } else {
 
-      implConformance = sec.innerText.innerHTML;
+      implConformance = sec.innerText;
 
     }
 
@@ -640,36 +645,72 @@ function insertConformance(docMetadata) {
     logger_.error("Conformance section not used in AGs.");
   }
 
-  sec.innerHTML = `
-  <h2>Conformance</h2>
-  <p>Normative text is text that describes elements of the design that are indispensable or contains the
-   conformance language keywords: "shall", "should", or "may". Informative text is text that is potentially
-    helpful to the user, but not indispensable, and can be removed, changed, or added editorially without
-     affecting interoperability. Informative text does not contain any conformance keywords. </p>
+  if (docMetadata.pubType !== smpte.EG_PUBTYPE) {
+    
+    sec.innerHTML = `
+    <h2>Conformance</h2>
+    <p>Normative text is text that describes elements of the design that are indispensable or contains the
+    conformance language keywords: "shall", "should", or "may". Informative text is text that is potentially
+      helpful to the user, but not indispensable, and can be removed, changed, or added editorially without
+      affecting interoperability. Informative text does not contain any conformance keywords. </p>
 
-  <p>All text in this document is, by default, normative, except: the Introduction, any clause explicitly
-  labeled as "Informative" or individual paragraphs that start with "Note:" </p>
+    <p>All text in this document is, by default, normative, except: the Introduction, any clause explicitly
+    labeled as "Informative" or individual paragraphs that start with "Note:" </p>
 
-<p>The keywords "shall" and "shall not" indicate requirements strictly to be followed in order to conform to the
-document and from which no deviation is permitted.</p>
+  <p>The keywords "shall" and "shall not" indicate requirements strictly to be followed in order to conform to the
+  document and from which no deviation is permitted.</p>
 
-<p>The keywords, "should" and "should not" indicate that, among several possibilities, one is recommended
-  as particularly suitable, without mentioning or excluding others; or that a certain course of action
-  is preferred but not necessarily required; or that (in the negative form) a certain possibility
-   or course of action is deprecated but not prohibited.</p>
+  <p>The keywords, "should" and "should not" indicate that, among several possibilities, one is recommended
+    as particularly suitable, without mentioning or excluding others; or that a certain course of action
+    is preferred but not necessarily required; or that (in the negative form) a certain possibility
+    or course of action is deprecated but not prohibited.</p>
 
-<p>The keywords "may" and "need not" indicate courses of action permissible within the limits of the document. </p>
+  <p>The keywords "may" and "need not" indicate courses of action permissible within the limits of the document. </p>
 
-<p>The keyword "reserved" indicates a provision that is not defined at this time, shall not be used,
-  and may be defined in the future. The keyword "forbidden" indicates "reserved" and in addition
-   indicates that the provision will never be defined in the future.</p>
+  <p>The keyword "reserved" indicates a provision that is not defined at this time, shall not be used,
+    and may be defined in the future. The keyword "forbidden" indicates "reserved" and in addition
+    indicates that the provision will never be defined in the future.</p>
 
-${implConformance}
+  ${implConformance}
 
-<p>Unless otherwise specified, the order of precedence of the types of normative information in
-  this document shall be as follows: Normative prose shall be the authoritative definition;
-  tables shall be next; then formal languages; then figures; and then any other language forms.</p>
-  `;
+  <p>Unless otherwise specified, the order of precedence of the types of normative information in
+    this document shall be as follows: Normative prose shall be the authoritative definition;
+    tables shall be next; then formal languages; then figures; and then any other language forms.</p>
+    `;
+
+  } else {
+
+    sec.innerHTML = `
+    <h2>Conformance</h2>
+    <p>This Engineering Guideline is purely informative and meant to provide tutorial information to the 
+    industry. It does not impose Conformance Requirements and avoids the use of Conformance Notation.</p>
+
+    <p>Engineering Guidelines frequently provide tutorial information about a Standard or Recommended Practice
+    and when this is the case, the user should rely on the Standards and Recommended Practices referenced for
+    interoperability information.</p>
+    `;
+
+  }
+
+  if (docMetadata.pubType === smpte.EG_PUBTYPE) {
+    
+    const sections = document.querySelectorAll('section');
+    sections.forEach((element) => {
+      let id = element.id;
+      if ((id !== "sec-front-matter") && (id !== "sec-foreword") && (id !== "sec-conformance")) {
+        if (element.innerText.includes("shall")) {
+          logger_.error(`EG must not contain Conformance Notation - "shall" found`, element);
+        }
+        if (element.innerText.includes("should")) {
+          logger_.error(`EG must not contain Conformance Notation - "should" found`, element);
+        }
+        if (element.innerText.includes("may")) {
+          logger_.error(`EG must not contain Conformance Notation - "may" found`, element);
+        }
+      }
+    });
+  }
+
 }
 
 const SMPTE_FOREWORD_ID = "sec-foreword";

--- a/smpte.js
+++ b/smpte.js
@@ -693,25 +693,24 @@ function insertConformance(docMetadata) {
 
   if (docMetadata.pubType === smpte.EG_PUBTYPE) {
     
-    const sections = document.querySelectorAll('section');
-    sections.forEach((element) => {
-   
-      const id = element.id;
-
-      if (id === "sec-front-matter" || id === "sec-foreword" || id === "sec-conformance")
-        return;
+    for (let section of document.querySelectorAll("body > section")) {
+    
+      let id = section.id;
       
-      if (element.innerText.toLowerCase().includes("shall")) {
-        logger_.error(`EG must not contain Conformance Notation - "shall" found`, element);
+      if (id === "sec-front-matter" || id === "sec-foreword" || id === "sec-conformance")
+        continue;
+      
+      if (section.innerText.toLowerCase().includes("shall")) {
+        logger_.error(`EG must not contain Conformance Notation - "shall" found`, section);
       }
-      if (element.innerText.toLowerCase().includes("should")) {
-        logger_.error(`EG must not contain Conformance Notation - "should" found`, element);
+      if (section.innerText.toLowerCase().includes("should")) {
+        logger_.error(`EG must not contain Conformance Notation - "should" found`, section);
       }
-      if (element.innerText.toLowerCase().includes("may")) {
-        logger_.error(`EG must not contain Conformance Notation - "may" found`, element);
+      if (section.innerText.toLowerCase().includes("may")) {
+        logger_.error(`EG must not contain Conformance Notation - "may" found`, section);
       }
     
-    });
+    };
   }
 
 }

--- a/test/resources/html/validation/eg-conformance-valid.html
+++ b/test/resources/html/validation/eg-conformance-valid.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head itemscope="itemscope" itemtype="http://smpte.org/standards/documents">
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="module" src="../../../../smpte.js"></script>
+    <meta itemprop="test" content="valid" />
+    <meta itemprop="pubType" content="EG" />
+    <meta itemprop="pubNumber" content="429" />
+    <meta itemprop="pubPart" content="6" />
+    <meta itemprop="pubSuiteTitle" content="Suite title" />
+    <meta itemprop="pubTC" content="27C" />
+    <meta itemprop="pubStage" content="WD" />
+    <meta itemprop="pubState" content="draft" />
+    <title>Title of the document</title>
+  </head>
+  <body>
+    <section id="sec-scope">
+      <p>This is the scope of the document.</p>
+    </section>
+    <section id="sec-a">
+      <h2>A</h2>
+      <p>The cat is blue.</p>
+    </section>
+  </body>
+</html>


### PR DESCRIPTION
Change default text of the `Conformance` section for EG docs, and check for conformance language within the doc (outside of the default sections. 