### PR TITLE
Formatting of URLs for references

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -36,7 +36,7 @@
   <section id="sec-normative-references">
     <ul>
       <li>
-        <cite id="bib-HTML-5">HTML Standard</cite>, Living Standard. 
+        <cite id="bib-HTML-5">HTML Standard</cite>, Living Standard 
         <a>https://html.spec.whatwg.org/multipage/</a></li>
     </ul>
   </section>
@@ -2369,11 +2369,11 @@ This is an &lt;code&gt;element&lt;/code&gt; that is rendered with the &lt;code&g
   <section id="sec-bibliography">
     <ul>
       <li><cite id="bib-iso-directives-part2">ISO/IEC Directives, Part 2</cite>, Principles and rules for the structure and drafting
-      of ISO and IEC documents (Ninth edition, 2021).
+      of ISO and IEC documents (Ninth edition, 2021)
       <a>https://www.iso.org/sites/directives/current/part2/index.xhtml</a></li>
-      <li><cite id="bib-smpte-ag-02">SMPTE AG 02</cite>, Document Naming and Packaging.
+      <li><cite id="bib-smpte-ag-02">SMPTE AG 02</cite>, Document Naming and Packaging
         <a>https://doc.smpte-doc.org/ag-02/main/</a></li>
-      <li><cite id="bib-smpte-ag-16">SMPTE AG 16</cite>, Standards Style Guide.
+      <li><cite id="bib-smpte-ag-16">SMPTE AG 16</cite>, Standards Style Guide
       <a>https://doc.smpte-doc.org/ag-16/main/</a></li>
       <li><cite id="bib-smpte-gh-om">SMPTE GitHub Operating Manual</cite>
         <a>https://github.com/SMPTE/github-operating-manual</a></li>

--- a/smpte.js
+++ b/smpte.js
@@ -457,6 +457,7 @@ function insertNormativeReferences(docMetadata) {
 
   for(const u of sec.querySelectorAll("ul a")) {
     u.parentNode.insertBefore(document.createElement("br"), u);
+    u.parentNode.insertBefore(document.createTextNode("url:\u00a0"), u);
   }
 }
 
@@ -545,6 +546,7 @@ function insertBibliography(docMetadata) {
 
   for(const u of sec.querySelectorAll("ul a")) {
     u.parentNode.insertBefore(document.createElement("br"), u);
+    u.parentNode.insertBefore(document.createTextNode("url:\u00a0"), u);
   }
 }
 

--- a/smpte.js
+++ b/smpte.js
@@ -456,7 +456,7 @@ function insertNormativeReferences(docMetadata) {
   /* style URLs */
 
   for(const u of sec.querySelectorAll("ul a")) {
-    u.parentNode.insertBefore(document.createTextNode("url:\u00a0"), u);
+    u.parentNode.insertBefore(document.createElement("br"), u);
   }
 }
 
@@ -544,7 +544,7 @@ function insertBibliography(docMetadata) {
   /* style links */
 
   for(const u of sec.querySelectorAll("ul a")) {
-    u.parentNode.insertBefore(document.createTextNode("url:\u00a0"), u);
+    u.parentNode.insertBefore(document.createElement("br"), u);
   }
 }
 


### PR DESCRIPTION
Always make urls for references on a new line to account for long reference titles and readability. No new line is created if there is no link. 

This is per request on late comments for editorials updates on a DP ballot by @ERyan71258 