### PR TITLE
Fix Foreword example

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -458,7 +458,7 @@
 
           <div class="example">
 <pre>
-&lt;section id=&quot;element-proponent&quot;&gt;
+&lt;section id=&quot;sec-foreword&quot;&gt;
   &lt;p&gt;This is the additional information relevant to the document.&lt;/p&gt;
   &lt;dl id=&quot;rdd-proponent&quot;&gt;
     &lt;dt&gt;Company 1 Name Here&lt;/dt&gt;


### PR DESCRIPTION
I'm pretty sure "element-proponent" is supposed to be "sec-foreword" in this example. Please verify.