### PR TITLE
action.yml: Configure git to use HTTPS for GitHub repos

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -192,8 +192,12 @@ async function build(buildPaths, baseRef, lastEdRef, docMetadata) {
 
     console.log(`Generating a redline against base: ${baseRef}.`);
 
-    await generateRedline(buildPaths, baseRef, buildPaths.baseRedLineRefPath, buildPaths.baseRedlinePath);
-    generatedFiles.baseRedline = buildPaths.baseRedlineName;
+    try {
+      await generateRedline(buildPaths, baseRef, buildPaths.baseRedLineRefPath, buildPaths.baseRedlinePath);
+      generatedFiles.baseRedline = buildPaths.baseRedlineName;
+    } catch (e) {
+      console.warn(`Could not generate a redline: ${e}.`);
+    }
 
   }
 
@@ -203,8 +207,12 @@ async function build(buildPaths, baseRef, lastEdRef, docMetadata) {
 
     console.log(`Generating a redline against the latest edition tag: ${lastEdRef}.`);
 
-    await generateRedline(buildPaths, lastEdRef, buildPaths.pubRedLineRefPath, buildPaths.pubRedlinePath);
-    generatedFiles.pubRedline = buildPaths.pubRedlineName;
+    try {
+      await generateRedline(buildPaths, lastEdRef, buildPaths.pubRedLineRefPath, buildPaths.pubRedlinePath);
+      generatedFiles.pubRedline = buildPaths.pubRedlineName;
+    } catch (e) {
+      console.warn(`Could not generate a redline: ${e}.`);
+    }
 
   }
 


### PR DESCRIPTION
build.mjs runs a number of git commands including cloning repos (and their submodules). Any operation using SSH fails because SSH is not configured on the runner. For example, submodules might be configured using SSH (with "git@github.com" in ".gitmodules").

This commit configures git so that all uses of SSH for GitHub repos are automatically replaced with HTTPS. This is comparable to the behaviour of https://github.com/actions/checkout which notes "When the `ssh-key` input is not provided, SSH URLs beginning with `git@github.com:` are converted to HTTPS"

This is added to action.yml rather than to build.mjs because it aims to configure the runner environment -- if build.mjs is run in other contexts (e.g. local machine) then a different configuration might be needed.