### PR TITLE
Move Conformance to Clause 4

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -9,7 +9,7 @@
   <meta itemprop="pubType" content="AG">
   <meta itemprop="pubNumber" content="26">
   <!-- <meta itemprop="pubPart" content="XX"> -->
-  <meta itemprop="pubState" content="pub">
+  <meta itemprop="pubState" content="draft">
   <meta itemprop="pubStage" content="PUB">
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->

--- a/doc/main.html
+++ b/doc/main.html
@@ -14,7 +14,7 @@
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->
   <meta itemprop="pubSuiteTitle" content="HTML Pub">
-  <meta itemprop="pubDateTime" content="2026-05-05">
+  <meta itemprop="pubDateTime" content="2026-05-12">
   <!-- <meta itemprop="pubRevisionOf" content="SMPTE ST XXXX-Y:ZZZZ"> -->
   <title>Tooling and documentation for HTML documents</title>
 </head>
@@ -417,14 +417,14 @@
               <td><a>Scope</a></td>
               <td>Exactly 1</td>
             <tr>
-              <td><a>Conformance</a></td>
-              <td>0 or 1</td>
-            </tr>
-            <tr>
               <td><a>Normative references</a></td>
               <td>0 or 1</td>
             <tr>
               <td><a>Terms and definitions</a></td>
+              <td>0 or 1</td>
+            </tr>
+            <tr>
+              <td><a>Conformance</a></td>
               <td>0 or 1</td>
             </tr>
             <tr>
@@ -553,30 +553,6 @@
   &lt;p&gt;This is the scope.&lt;/p&gt;
 &lt;/section&gt;</pre>
         </div>
-
-      </section>
-
-      <section id="sec-conformance-section">
-        <h4>Conformance <code>section</code></h4>
-
-        <p>The <dfn>Conformance</dfn> <code>section</code> contains author-supplied, conformance-related prose that is added to the SMPTE
-        boilerplate text that is generated depending on <code>pubType</code>.</p>
-
-        <p>The absence of this <code>section</code> indicates that no author-supplied, conformance-related prose is provided.</p>
-
-        <p>The <code>id</code> attribute shall be present on the <code>section</code> element and equal to
-        <code>sec-conformance</code>.</p>
-
-        <p>The heading shall not be present.</p>
-
-        <div class="example">
-<pre>&lt;section id=&quot;sec-conformance&quot;&gt;
-  &lt;p&gt;These are additional conformance requirements and definitions.&lt;/p&gt;
-&lt;/section&gt;
-</pre>
-        </div>
-
-        <p>This <code>section</code> is prohibited unless the document is a Standard or Recommended Practice.</p>
 
       </section>
 
@@ -709,6 +685,34 @@
         </div>
 
         <p class="note">The boilerplate of the clause will be generated automatically.</p>
+
+      </section>
+
+      <section id="sec-conformance-section">
+        <h4>Conformance <code>section</code></h4>
+
+        <p>The <dfn>Conformance</dfn> <code>section</code> contains author-supplied, conformance-related prose that is added to the SMPTE
+        boilerplate text that is generated depending on <code>pubType</code>.</p>
+
+        <p>The <a>Conformance</a> <code>section</code> follows <a>Terms and definitions</a> and is the first SMPTE-defined clause that
+        may carry substantive conformance requirements. It is positioned consistent with ISO/IEC Directives, Part 2, which reserve
+        Clauses 1, 2, and 3 for <a>Scope</a>, <a>Normative references</a>, and <a>Terms and definitions</a> respectively.</p>
+
+        <p>The absence of this <code>section</code> indicates that no author-supplied, conformance-related prose is provided.</p>
+
+        <p>The <code>id</code> attribute shall be present on the <code>section</code> element and equal to
+        <code>sec-conformance</code>.</p>
+
+        <p>The heading shall not be present.</p>
+
+        <div class="example">
+<pre>&lt;section id=&quot;sec-conformance&quot;&gt;
+  &lt;p&gt;These are additional conformance requirements and definitions.&lt;/p&gt;
+&lt;/section&gt;
+</pre>
+        </div>
+
+        <p>This <code>section</code> is prohibited unless the document is a Standard or Recommended Practice.</p>
 
       </section>
 

--- a/js/validate.mjs
+++ b/js/validate.mjs
@@ -1155,11 +1155,6 @@ function validateBody(body, logger) {
     logger.error("Mandatory Scope clause missing", elements[0]);
   }
 
-  /* validate optional conformance */
-
-  if (elements.length > 0 && ConformanceMatcher.match(elements[0], logger))
-    elements.shift();
-
   /* validate optional normative references */
 
   if (elements.length > 0 && NormativeReferencesMatcher.match(elements[0], logger))
@@ -1168,6 +1163,11 @@ function validateBody(body, logger) {
   /* validate optional terms and definitions */
 
   if (elements.length > 0 && DefinitionsMatcher.match(elements[0], logger))
+    elements.shift();
+
+  /* validate optional conformance */
+
+  if (elements.length > 0 && ConformanceMatcher.match(elements[0], logger))
     elements.shift();
 
   /* validate zero or more clauses */

--- a/smpte.js
+++ b/smpte.js
@@ -701,7 +701,7 @@ function insertConformance(docMetadata) {
       helpful to the user, but not indispensable, and can be removed, changed, or added editorially without
       affecting interoperability. Informative text does not contain any conformance keywords. </p>
 
-    <p>All text in this document is, by default, normative, except: the Introduction, any clause explicitly
+    <p>All text in this document is, by default, normative, except: the Introduction, the Bibliography, or any clause explicitly
     labeled as "Informative" or individual paragraphs that start with "Note:" </p>
 
   <p>The keywords "shall" and "shall not" indicate requirements strictly to be followed in order to conform to the

--- a/smpte.js
+++ b/smpte.js
@@ -422,7 +422,7 @@ function insertNormativeReferences(docMetadata) {
   if (sec === null) {
     sec = document.createElement("section");
     sec.id = SMPTE_NORM_REFS_ID;
-    document.body.insertBefore(sec, document.getElementById(SMPTE_CONFORMANCE_ID).nextSibling);
+    document.body.insertBefore(sec, document.getElementById(SMPTE_SCOPE_ID).nextSibling);
   }
 
   const p = document.createElement("p");
@@ -665,7 +665,10 @@ function insertConformance(docMetadata) {
     sec = document.createElement("section");
     sec.id = SMPTE_CONFORMANCE_ID;
 
-    document.body.insertBefore(sec, document.getElementById(SMPTE_SCOPE_ID).nextSibling);
+    const anchor = document.getElementById(SMPTE_TERMS_ID)
+      || document.getElementById(SMPTE_NORM_REFS_ID)
+      || document.getElementById(SMPTE_SCOPE_ID);
+    document.body.insertBefore(sec, anchor.nextSibling);
   }
 
   let implConformance = "";
@@ -1561,9 +1564,9 @@ async function render() {
   insertForeword(docMetadata);
   insertIntroduction(docMetadata);
   insertScope(docMetadata);
-  insertConformance(docMetadata);
   insertNormativeReferences(docMetadata);
   insertTermsAndDefinitions(docMetadata);
+  insertConformance(docMetadata);
 
   insertElementsAnnex(docMetadata);
   insertBibliography(docMetadata);

--- a/test/resources/html/validation/st-conformance-invalid.html
+++ b/test/resources/html/validation/st-conformance-invalid.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head itemscope="itemscope" itemtype="http://smpte.org/standards/documents">
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script type="module" src="../../../../smpte.js"></script>
+    <meta itemprop="test" content="invalid" />
+    <meta itemprop="pubType" content="ST" />
+    <meta itemprop="pubNumber" content="2650" />
+    <meta itemprop="pubTC" content="27C" />
+    <meta itemprop="pubStage" content="WD" />
+    <meta itemprop="pubState" content="draft" />
+    <title>Title of the document</title>
+  </head>
+  <body>
+    <section id="sec-conformance">
+      <p>These are additional conformance requirements and definitions.</p>
+    </section>
+    <section id="sec-scope">
+      <p>This is the scope of the document.</p>
+    </section>
+  </body>
+</html>

--- a/test/resources/html/validation/st-conformance-valid.html
+++ b/test/resources/html/validation/st-conformance-valid.html
@@ -5,32 +5,18 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script type="module" src="../../../../smpte.js"></script>
-    <meta itemprop="test" content="invalid" />
-    <meta itemprop="pubType" content="RDD" />
-    <meta itemprop="pubNumber" content="26" />
-    <meta itemprop="pubState" content="draft" />
+    <meta itemprop="test" content="valid" />
+    <meta itemprop="pubType" content="ST" />
+    <meta itemprop="pubNumber" content="2650" />
+    <meta itemprop="pubTC" content="27C" />
     <meta itemprop="pubStage" content="WD" />
-    <meta itemprop="pubTC" content="XX" />
-    <meta itemprop="pubConfidential" content="yes" />
-    <meta itemprop="pubDateTime" content="2025-02-26" />
+    <meta itemprop="pubState" content="draft" />
     <title>Title of the document</title>
   </head>
   <body>
-
-    <section id="sec-foreword">
-      <dl id="element-proponents">
-        <dt>Company name</dt>
-          <dd>Contact name</dd>
-          <dd>Contact email</dd>
-          <dd>Company Address</dd>
-          <dd>Company website</dd>
-      </dl>
-    </section>
-    
     <section id="sec-scope">
       <p>This is the scope of the document.</p>
     </section>
-
     <section id="sec-conformance">
       <p>These are additional conformance requirements and definitions.</p>
     </section>


### PR DESCRIPTION
Reorder body sections to `Scope` → `Normative references` → `Terms and definitions` → `Conformance`, aligning with ISO/IEC Directives Part 2 which reserve Clauses 1–3 for `Scope`, `Normative references`, and `Terms and definitions`.

Added tests. 

Closes #405. 

This change was approved by ST - 2026-04-07 meeting. 

