### PR TITLE
Remove example containing a link to polyfill.io

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -359,10 +359,7 @@
         document layout, e.g. <a href="https://www.mathjax.org/">MathJax</a></p>
 
           <div class="example">
-<pre>&lt;script src=&quot;https://polyfill.io/v3/polyfill.min.js?features=es6&quot;&gt;&lt;/script&gt;
-&lt;script type=&quot;text/javascript&quot; id=&quot;MathJax-script&quot;
-  async src=&quot;https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js&quot;&gt;
-&lt;/script&gt;</pre>
+<pre>&lt;script id=&quot;MathJax-script&quot; async src=&quot;https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js&quot;&gt;&lt;/script&gt;</pre>
           </div>
 
 


### PR DESCRIPTION
https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk/

Thanks to @thomasheritage for raising this