### PR TITLE
Remove PDF gen

### DIFF
--- a/css/smpte.css
+++ b/css/smpte.css
@@ -482,7 +482,8 @@ div.formula {
 }
 
 div.formula > math {
-  width: 90%;
+  display: table-cell;
+  width: 100%;
   text-align: center;
 }
 

--- a/css/smpte.css
+++ b/css/smpte.css
@@ -477,18 +477,20 @@ figure {
 /* formulae */
 
 div.formula {
-  display: table;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
   width: 100%;
 }
 
 div.formula > math {
-  display: table-cell;
-  width: 100%;
+  grid-column: 2;
   text-align: center;
 }
 
 div.formula > .heading-label {
-  display: table-cell;
+  grid-column: 3;
+  justify-self: end;
   text-align: right;
 }
 

--- a/doc/main.html
+++ b/doc/main.html
@@ -9,12 +9,12 @@
   <meta itemprop="pubType" content="AG">
   <meta itemprop="pubNumber" content="26">
   <!-- <meta itemprop="pubPart" content="XX"> -->
-  <meta itemprop="pubState" content="draft">
+  <meta itemprop="pubState" content="pub">
   <meta itemprop="pubStage" content="PUB">
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->
   <meta itemprop="pubSuiteTitle" content="HTML Pub">
-  <meta itemprop="pubDateTime" content="2026-06-10">
+  <meta itemprop="pubDateTime" content="2026-06-02">
   <!-- <meta itemprop="pubRevisionOf" content="SMPTE ST XXXX-Y:ZZZZ"> -->
   <title>Tooling and documentation for HTML documents</title>
 </head>

--- a/doc/main.html
+++ b/doc/main.html
@@ -9,12 +9,12 @@
   <meta itemprop="pubType" content="AG">
   <meta itemprop="pubNumber" content="26">
   <!-- <meta itemprop="pubPart" content="XX"> -->
-  <meta itemprop="pubState" content="pub">
+  <meta itemprop="pubState" content="draft">
   <meta itemprop="pubStage" content="PUB">
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->
   <meta itemprop="pubSuiteTitle" content="HTML Pub">
-  <meta itemprop="pubDateTime" content="2026-05-19">
+  <meta itemprop="pubDateTime" content="2026-06-10">
   <!-- <meta itemprop="pubRevisionOf" content="SMPTE ST XXXX-Y:ZZZZ"> -->
   <title>Tooling and documentation for HTML documents</title>
 </head>

--- a/doc/main.html
+++ b/doc/main.html
@@ -1097,7 +1097,7 @@
         property as a percentage value on each <code>th</code> element.</p>
 
         <p class="note">Page breaks are avoided within a <code>tbody</code>
-        element when generating PDF. Care should be taken for especially long
+        element when printing. Care should be taken for especially long
         tables to ensure rendering is as expected. For data in tables spanning
         multiple pages, other options should be considered and used.</p>
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -169,23 +169,6 @@ async function build(buildPaths, baseRef, lastEdRef, lastReleaseRef, docMetadata
 
   generatedFiles.html = buildPaths.renderedDocName;
 
-  /* create pdf */
-
-  generatedFiles.pdf = `SMPTE-${docMetadata.pubType}-${docMetadata.pubNumber}`;
-  if (docMetadata.pubPart !== null) {
-    generatedFiles.pdf += `-${docMetadata.pubPart}`
-  }
-  if (docMetadata.pubDateTime !== null) {
-    generatedFiles.pdf += `-${docMetadata.pubDateTime}`
-  }
-  if (docMetadata.pubPart !== null) {
-    generatedFiles.pdf += `-${docMetadata.pubSuiteTitle}`
-  }
-  generatedFiles.pdf += `-${docMetadata.pubTitle}.pdf`;
-  generatedFiles.pdf = generatedFiles.pdf.replace(/[\s—–‐‑]+/g, "-");
-
-  await makePDF(buildPaths.renderedDocPath, path.join(buildPaths.pubDirPath, generatedFiles.pdf));
-
   /* generate base redline, if requested */
 
   if (baseRef !== null) {
@@ -253,9 +236,6 @@ async function generatePubLinks(buildPaths, pubLinks) {
     if ("clean" in pubLinks)
       linksDocContents += `[Clean](${pubLinks.clean})\n`;
 
-    if ("pdf" in pubLinks)
-      linksDocContents += `[Clean PDF](${pubLinks.pdf})\n`;
-
     if ("baseRedline" in pubLinks)
       linksDocContents += `[Redline to current draft](${pubLinks.baseRedline})\n`;
 
@@ -303,10 +283,6 @@ async function s3Upload(buildPaths, versionKey, generatedFiles) {
     pubLinks.clean = `${deployPrefix}${s3PubKeyPrefix}`;
   }
 
-  if ("pdf" in generatedFiles) {
-    pubLinks.pdf = `${deployPrefix}${s3PubKeyPrefix}${encodeURIComponent(generatedFiles.pdf)}`;
-  }
-
   if ("baseRedline" in generatedFiles) {
     pubLinks.baseRedline = `${deployPrefix}${s3PubKeyPrefix}${encodeURIComponent(generatedFiles.baseRedline)}`;
   }
@@ -349,9 +325,6 @@ async function makeReviewZip(buildPaths, generatedFiles, docMetadata) {
 
   if ("html" in generatedFiles)
     zip.addLocalFile(path.join(buildPaths.pubDirPath, generatedFiles.html));
-
-  if ("pdf" in generatedFiles)
-    zip.addLocalFile(path.join(buildPaths.pubDirPath, generatedFiles.pdf));
 
   if ("pubRedline" in generatedFiles)
     zip.addLocalFile(path.join(buildPaths.pubDirPath, generatedFiles.pubRedline));
@@ -397,10 +370,6 @@ async function makePubArtifacts(buildPaths, generatedFiles, docMetadata) {
 
   if ("html" in generatedFiles) {
     htmlLinks = `<p><a href="${encodeURIComponent(generatedFiles.html)}">Clean</a></p>\n`;
-  }
-
-  if ("pdf" in generatedFiles) {
-    htmlLinks += `<p><a href="${encodeURIComponent(generatedFiles.pdf)}">Clean PDF</a></p>\n`;
   }
 
   if ("baseRedline" in generatedFiles) {
@@ -459,12 +428,6 @@ async function makeLibraryZip(buildPaths, generatedFiles, docMetadata) {
   if (generatedFiles.media.length > 0)
     manifest.media = generatedFiles.media;
 
-  if ("pdf" in generatedFiles)
-    manifest.main.push({
-      mediaType: "application/pdf",
-      path: generatedFiles.pdf
-    });
-
   if ("html" in generatedFiles)
     manifest.main.push({
       mediaType: "text/html",
@@ -513,77 +476,6 @@ async function makeLibraryZip(buildPaths, generatedFiles, docMetadata) {
   zip.writeZip(zipPath);
 
   return zipFn;
-}
-
-async function makePDF(docPath, pdfPath) {
-  const timeout = 6000000;
-
-  const browser = await puppeteer.launch({
-    args: ["--no-sandbox", "--disable-dev-shm-usage", "--allow-file-access-from-files"]
-  });
-
-
-  const page = await browser.newPage();
-  page.setDefaultTimeout(timeout);
-  await page.emulateMediaType("print");
-  await page.goto("file://" + path.resolve(docPath));
-  await page.content();
-  await page.evaluate(() => {
-    window.PagedConfig = window.PagedConfig || {};
-    window.PagedConfig.auto = false;
-  });
-  await page.addScriptTag({ url: 'https://cdn.jsdelivr.net/npm/pagedjs@0.4.3/dist/paged.polyfill.js' });
-
-  let renderingDone;
-  let rendered = new Promise(function (resolve, reject) {
-    renderingDone = resolve;
-  });
-  await page.exposeFunction("onRendered", (msg) => {
-    console.log(msg);
-    renderingDone();
-  });
-  await page.exposeFunction("onPage", (position) => {
-    if (position % 10 === 0) {
-      console.log("Rendering: Page " + (position + 1));
-    }
-  });
-  await page.evaluate(async () => {
-    document.querySelectorAll('#sec-elements a[href]')
-      .forEach(e => { if (!e.href.startsWith("http")) e.removeAttribute("href"); });
-
-    window.PagedPolyfill.on("page", (page) => {
-      window.onPage(page.position);
-    });
-    window.PagedPolyfill.on("rendered", (flow) => {
-      let msg = "Rendering " + flow.total + " pages took " + flow.performance + " milliseconds.";
-      window.onRendered(msg);
-    })
-    await window.PagedPolyfill.preview();
-  }).catch((error) => {
-    throw error;
-  });
-  await page.waitForNetworkIdle({
-    timeout: timeout
-  });
-  await rendered;
-  await page.waitForSelector(".pagedjs_pages");
-
-  const pdf = await page.pdf({
-    timeout: timeout,
-    printBackground: true,
-    displayHeaderFooter: false,
-    margin: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
-    }
-  });
-
-  fs.writeFileSync(pdfPath, pdf);
-
-  await browser.close();
-
 }
 
 async function render(docPath) {

--- a/smpte.js
+++ b/smpte.js
@@ -122,7 +122,7 @@ const SMPTE_FRONT_MATTER_BOILERPLATE = `<div id="doc-number-block">
 <div id="long-doc-type">{{longDocType}}</div>
 <h1>{{fullTitle}}</h1>
 <div id="doc-status">{{publicationState}} - {{actualPubDateTime}}</div>
-<p><span id="copyright-text">Copyright © <span id="doc-copyright-year">{{copyrightYear}}</span>,
+<p><span id="copyright-text">Copyright &#xA9; <span id="doc-copyright-year">{{copyrightYear}}</span>,
 Society of Motion Picture and Television Engineers</span>.
 All rights reserved. No part of this material may be reproduced, by any means whatsoever,
 without the prior written permission of the Society of Motion Picture and Television Engineers.</p>
@@ -135,7 +135,7 @@ const SMPTE_PUB_AG_FRONT_MATTER_BOILERPLATE = `<div id="doc-designator" itemscop
 <div id="long-doc-type">{{longDocType}}</div>
 <h1>{{fullTitle}}</h1>
 <div id="doc-status">{{publicationState}}: {{actualPubDateTime}}</div>
-<p><span id="copyright-text">Copyright © <span id="doc-copyright-year">{{copyrightYear}}</span>,
+<p><span id="copyright-text">Copyright &#xA9; <span id="doc-copyright-year">{{copyrightYear}}</span>,
 Society of Motion Picture and Television Engineers</span>.
 All rights reserved. No part of this material may be reproduced, by any means whatsoever,
 without the prior written permission of the Society of Motion Picture and Television Engineers.</p>
@@ -148,7 +148,7 @@ const SMPTE_PUB_OM_FRONT_MATTER_BOILERPLATE = `<div id="doc-designator" itemscop
 <h1>{{fullTitle}}</h1>
 <div id="doc-status">{{publicationState}}: {{actualPubDateTime}}</div>
 <div id="doc-effective">Effective date: {{effectiveDateTime}}</div>
-<p><span id="copyright-text">Copyright © <span id="doc-copyright-year">{{copyrightYear}}</span>,
+<p><span id="copyright-text">Copyright &#xA9; <span id="doc-copyright-year">{{copyrightYear}}</span>,
 Society of Motion Picture and Television Engineers</span>.
 All rights reserved. No part of this material may be reproduced, by any means whatsoever,
 without the prior written permission of the Society of Motion Picture and Television Engineers.</p>
@@ -244,7 +244,7 @@ function insertFrontMatter(docMetadata) {
   let fullTitle;
 
   if (docMetadata.pubSuiteTitle !== null)
-    fullTitle = `${docMetadata.pubSuiteTitle} — ${docMetadata.pubTitle}`;
+    fullTitle = `${docMetadata.pubSuiteTitle} &#x2014; ${docMetadata.pubTitle}`;
   else
     fullTitle = docMetadata.pubTitle;
 
@@ -769,9 +769,9 @@ const SMPTE_GEN_FOREWORD_BOILERPLATE = `<h2>Foreword</h2>
 <p>The Society of Motion Picture and Television Engineers (SMPTE) is an
 internationally-recognized standards developing organization. Headquartered
 and incorporated in the United States of America, SMPTE has members in over
-80 countries on six continents. SMPTE’s Engineering Documents, including
+80 countries on six continents. SMPTE's Engineering Documents, including
 Standards, Recommended Practices, and Engineering Guidelines, are prepared
-by SMPTE’s Technology Committees. Participation in these Committees is open
+by SMPTE's Technology Committees. Participation in these Committees is open
 to all with a bona fide interest in their work. SMPTE cooperates closely
 with other standards-developing organizations, including ISO, IEC and ITU.
 SMPTE Engineering Documents are drafted in accordance with the rules given
@@ -1042,7 +1042,7 @@ function numberTables() {
 
       headingLabel.appendChild(document.createTextNode("Table "));
       headingLabel.appendChild(headingNumberElement);
-      headingLabel.appendChild(document.createTextNode(" — "));
+      headingLabel.appendChild(document.createTextNode(" \u2014 "));
 
 
       caption.insertBefore(headingLabel, caption.firstChild);
@@ -1083,7 +1083,7 @@ function numberFigures() {
 
       headingLabel.appendChild(document.createTextNode("Figure "));
       headingLabel.appendChild(headingNumberElement);
-      headingLabel.appendChild(document.createTextNode(" — "));
+      headingLabel.appendChild(document.createTextNode(" \u2014 "));
 
 
       figcaption.insertBefore(headingLabel, figcaption.firstChild);
@@ -1182,7 +1182,7 @@ function numberSectionNotes(section) {
 
     headingLabel.appendChild(document.createTextNode("NOTE "));
     headingLabel.appendChild(headingNumberElement);
-    headingLabel.appendChild(document.createTextNode(" —⁠ "));
+    headingLabel.appendChild(document.createTextNode(" \u2014⁠ "));
 
     note.insertBefore(headingLabel, note.firstChild);
   }
@@ -1473,7 +1473,7 @@ function resolveLinks(docMetadata) {
 
       } else if (target.classList.contains("footnote")) {
 
-        /* footnote ref — letter already filled by numberTableFootnotes; wrap in <sup> */
+        /* footnote ref - letter already filled by numberTableFootnotes; wrap in <sup> */
         const sup = document.createElement("sup");
         anchor.replaceWith(sup);
         sup.appendChild(anchor);

--- a/smpte.js
+++ b/smpte.js
@@ -1593,14 +1593,6 @@ async function render() {
 
   asyncFunctions.push(asyncInsertSnippets());
 
-  /* debug print version */
-  if (docMetadata.media === "print") {
-    let pagedJS = document.createElement("script");
-    pagedJS.setAttribute("src", "https://cdn.jsdelivr.net/npm/pagedjs@0.4.3/dist/paged.polyfill.js");
-    pagedJS.id = "paged-js-script";
-    document.head.appendChild(pagedJS);
-  }
-
   return Promise.all(asyncFunctions);
 }
 


### PR DESCRIPTION
## Summary

Removes the tooling-based PDF rendering pipeline. HTML is the authoritative version of
SMPTE Engineering Documents; the generated PDF was convenience-only and consistently low
quality. Anyone who needs a PDF can use their browser's **Print to PDF**. This implements
the direction agreed in #407.

## What changed

- **Dropped the PDF build pass** (`scripts/build.mjs`): removed the `makePDF()` Puppeteer +
  paged.js renderer, the PDF filename assembly, and all PDF plumbing — review-link entry,
  S3 URL, review-zip file, artifact link, and the `application/pdf` manifest entry (~108 lines).
- **Removed the client-side paged.js injection** (`smpte.js`): the `?media=print` debug path
  that pulled `paged.polyfill.js` from a CDN is gone.
- **Doc note** (`doc/main.html`): reworded the `tbody` page-break note from "when generating
  PDF" to "when printing."

> Puppeteer is intentionally **retained** — `render()` still uses headless Chromium to execute
> the page and emit the authoritative static HTML. It was never PDF-only.

Also on this branch:
- **Formula numbering** (`css/smpte.css`): the equation is now centered to the page with the
  number right-aligned at the margin (3-column grid).
- **Boilerplate** (`smpte.js`): replaced literal smart-punctuation codepoints (curly
  apostrophes, `©`, em dashes) with straight characters / references, in line with
  `ILLEGAL_CHARS_RE`.

## Print CSS

The print stylesheet is kept as-is — the `@media print` / `@page` rules and `break-*` hints
remain so browser Print to PDF still produces sensible page breaks. Running headers/footers
are now browser-native rather than paged.js-driven.

## Verification

- `npm test` (validation suite) — passes.
- `node --check` passes for `build.mjs` and `smpte.js`; module imports resolve.
- No residual `makePDF` / `pagedjs` / `application/pdf` references.
- **End-to-end build:** validated in the test-document repo by pointing its `tooling`
  submodule at this change and running a full publish build — produces the rendered HTML
  and zips with no PDF and no Puppeteer PDF pass.
  See SMPTE/tst123-4-private#1 (`test PDF gen removal`, commit `3e8008f`).

## Issues

Closes #407

Resolved by retiring the PDF tooling:
- Closes #222
- Closes #223
- Closes #253
- Closes #281
- Closes #396
- Closes #260
- Closes #259
- Closes #234
- Closes #107
- Closes #217
- Closes #404
- Closes #235
- Closes #216

Partially addressed — PDF rendering is removed, but the HTML-side issue remains open:
- #254 (HTML title page still missing SMPTE contact information)