### PR TITLE
Centralize build (build-reusable.yml) and bump Node

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -1,0 +1,86 @@
+name: Build SMPTE document (reusable)
+
+# Central build pipeline for all SMPTE document repositories. Each document
+# repo's .github/workflows/main.yml is a thin stub that calls this workflow,
+# so action/Node bumps and step changes happen here once instead of in every
+# repo. The build/validation code itself still comes from the `tooling`
+# submodule (resolved via `uses: ./tooling/workflows` against the caller's
+# checkout), so it stays pinned by each repo's submodule SHA.
+
+on:
+  workflow_call:
+
+env:
+  AWS_REGION: us-east-1
+  AWS_S3_BUCKET: html-doc-pub
+  AWS_ROLE: arn:aws:iam::189079736792:role/gh-actions-html-pub
+  CANONICAL_LINK_PREFIX: https://doc.smpte-doc.org/
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner	== 'SMPTE' && (
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || github.event_name == 'pull_request'
+      || github.event_name == 'release'
+      )
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Set repository name
+        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
+
+      - name: Check out all branches with the exception of the current branch
+        run: CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD); for i in `git branch -a | grep remote | grep -v "remotes/pull" | grep -v HEAD | grep -v ${CUR_BRANCH}`; do git branch --track ${i#remotes/origin/} $i; done
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build and deploy document (local)
+        uses: ./tooling/workflows
+        if: github.repository != 'SMPTE/html-pub'
+        with:
+          AWS_S3_REGION: ${{env.AWS_REGION}}
+          AWS_S3_BUCKET: 	${{env.AWS_S3_BUCKET}}
+          AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
+          CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PUBLIC_REPO_PAT: ${{secrets.PUBLIC_REPO_PAT}}
+
+      - name: Build and deploy document (HTML Pub repo)
+        uses: ./workflows
+        if: github.repository == 'SMPTE/html-pub'
+        with:
+          AWS_S3_REGION: ${{env.AWS_REGION}}
+          AWS_S3_BUCKET: 	${{env.AWS_S3_BUCKET}}
+          AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
+          CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PUBLIC_REPO_PAT: ${{secrets.PUBLIC_REPO_PAT}}
+
+      - name: Notify template repo to update submodule
+        if: github.event_name == 'release' && github.repository == 'SMPTE/html-pub'
+        env:
+          GH_TOKEN: ${{ secrets.TEMPLATE_REPO_PAT }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          gh api repos/SMPTE/html-pub-template/dispatches \
+            --method POST \
+            --field event_type=tooling-release \
+            --field "client_payload[tag]=${TAG_NAME}" \
+            --field "client_payload[sha]=${GITHUB_SHA}"

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -6,9 +6,28 @@ name: Build SMPTE document (reusable)
 # repo. The build/validation code itself still comes from the `tooling`
 # submodule (resolved via `uses: ./tooling/workflows` against the caller's
 # checkout), so it stays pinned by each repo's submodule SHA.
+#
+# "Enforce official tooling" replaces the old byte-exact `cmp` guard:
+#   - provenance: the `tooling` submodule must point at the official html-pub
+#     repo (no forks) — checked on every build.
+#   - currency: the recorded submodule commit must match the latest official
+#     `main` — a build only happens when someone is editing the document, and
+#     editors must be on current tooling. OVERRIDE_SUBMODULE_SHA / _REF are the
+#     sanctioned escape hatch for testing or rebuilding an old release.
 
 on:
   workflow_call:
+    inputs:
+      OVERRIDE_SUBMODULE_SHA:
+        description: "Pin enforcement to this tooling SHA instead of latest official main (testing / deliberate rebuild). Mismatch warns instead of failing."
+        required: false
+        type: string
+        default: ""
+      OVERRIDE_SUBMODULE_REF:
+        description: "Pin enforcement to this tooling ref (e.g. a branch) instead of latest official main. Mismatch warns instead of failing."
+        required: false
+        type: string
+        default: ""
 
 env:
   AWS_REGION: us-east-1
@@ -38,6 +57,76 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+
+      - name: Enforce official tooling
+        if: github.repository != 'SMPTE/html-pub'
+        shell: bash
+        env:
+          SUB_PATH: tooling
+          OFFICIAL_URL: https://github.com/SMPTE/html-pub.git
+          OFFICIAL_BRANCH: main
+          OVERRIDE_SHA: ${{ inputs.OVERRIDE_SUBMODULE_SHA }}
+          OVERRIDE_REF: ${{ inputs.OVERRIDE_SUBMODULE_REF }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -f ".gitmodules" ]]; then
+            echo "ERROR: .gitmodules not found. This repository must declare the '${SUB_PATH}' submodule."
+            exit 1
+          fi
+
+          # --- Provenance: submodule must point at the official tooling repo (no forks) ---
+          URL_IN_MODULES=$(git config -f .gitmodules --get "submodule.${SUB_PATH}.url" || true)
+          if [[ "$URL_IN_MODULES" != "$OFFICIAL_URL" ]]; then
+            echo "ERROR: ${SUB_PATH} URL in .gitmodules is '$URL_IN_MODULES' but must be '$OFFICIAL_URL'."
+            echo "Forked or relocated tooling is not permitted. Fix .gitmodules to use the official URL."
+            exit 1
+          fi
+
+          RECORDED_SHA=$(git ls-tree HEAD "$SUB_PATH" | awk '{print $3}')
+          if [[ -z "${RECORDED_SHA:-}" ]]; then
+            echo "ERROR: No submodule commit recorded for ${SUB_PATH}. Did you add and commit the submodule?"
+            exit 1
+          fi
+
+          # --- Currency: submodule must be on the latest official tooling ---
+          if [[ -n "${OVERRIDE_SHA:-}" ]]; then
+            TARGET_SHA="$OVERRIDE_SHA"
+          elif [[ -n "${OVERRIDE_REF:-}" ]]; then
+            TARGET_SHA=$(git ls-remote "$OFFICIAL_URL" "$OVERRIDE_REF" | awk '{print $1}')
+            if [[ -z "${TARGET_SHA:-}" ]]; then
+              echo "ERROR: Could not resolve override ref '$OVERRIDE_REF' on '$OFFICIAL_URL'."
+              exit 1
+            fi
+          else
+            TARGET_SHA=$(git ls-remote "$OFFICIAL_URL" "refs/heads/$OFFICIAL_BRANCH" | awk '{print $1}')
+            if [[ -z "${TARGET_SHA:-}" ]]; then
+              echo "ERROR: Could not read '$OFFICIAL_BRANCH' from '$OFFICIAL_URL'."
+              exit 1
+            fi
+          fi
+
+          echo "Recorded(${SUB_PATH}): $RECORDED_SHA"
+          echo "Target  (${SUB_PATH}): $TARGET_SHA"
+
+          if [[ "$RECORDED_SHA" != "$TARGET_SHA" ]]; then
+            if [[ -n "${OVERRIDE_SHA:-}" || -n "${OVERRIDE_REF:-}" ]]; then
+              echo "::warning::Tooling submodule mismatch (override active). Recorded=${RECORDED_SHA} Target=${TARGET_SHA}"
+            else
+              echo "ERROR: Tooling submodule is not on the latest official '${OFFICIAL_BRANCH}'."
+              echo
+              echo "You are editing this document, so the tooling must be current. To update:"
+              echo "  git submodule update --init --remote -- \"${SUB_PATH}\""
+              echo "  git add \"${SUB_PATH}\""
+              echo "  git commit -m \"Bump ${SUB_PATH} to latest ${OFFICIAL_BRANCH}\""
+              echo
+              echo "To intentionally pin (testing, or rebuilding an old release), set"
+              echo "OVERRIDE_SUBMODULE_SHA (or OVERRIDE_SUBMODULE_REF) in the caller stub's 'with:' block."
+              exit 1
+            fi
+          fi
+
+          echo "Official tooling confirmed."
 
       - name: Set repository name
         run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,77 +6,14 @@ on:
   release:
     types: [published]
 
-env:
-  AWS_REGION: us-east-1
-  AWS_S3_BUCKET: html-doc-pub
-  AWS_ROLE: arn:aws:iam::189079736792:role/gh-actions-html-pub
-  CANONICAL_LINK_PREFIX: https://doc.smpte-doc.org/
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    if: >
-      github.repository_owner	== 'SMPTE' && (
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-      || github.event_name == 'pull_request'
-      || github.event_name == 'release'
-      )
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
       contents: write
       pull-requests: write
-
-    steps:
-
-      - name: Checkout repo
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          submodules: true
-
-      - name: Set repository name
-        run: echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
-
-      - name: Check out all branches with the exception of the current branch
-        run: CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD); for i in `git branch -a | grep remote | grep -v "remotes/pull" | grep -v HEAD | grep -v ${CUR_BRANCH}`; do git branch --track ${i#remotes/origin/} $i; done
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ env.AWS_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Build and deploy document (local)
-        uses: ./tooling/workflows
-        if: github.repository != 'SMPTE/html-pub'
-        with:
-          AWS_S3_REGION: ${{env.AWS_REGION}}
-          AWS_S3_BUCKET: 	${{env.AWS_S3_BUCKET}}
-          AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
-          CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PUBLIC_REPO_PAT: ${{secrets.PUBLIC_REPO_PAT}}
-
-      - name: Build and deploy document (HTML Pub repo)
-        uses: ./workflows
-        if: github.repository == 'SMPTE/html-pub'
-        with:
-          AWS_S3_REGION: ${{env.AWS_REGION}}
-          AWS_S3_BUCKET: 	${{env.AWS_S3_BUCKET}}
-          AWS_S3_KEY_PREFIX: "${{env.REPOSITORY_NAME}}/"
-          CANONICAL_LINK_PREFIX: ${{env.CANONICAL_LINK_PREFIX}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PUBLIC_REPO_PAT: ${{secrets.PUBLIC_REPO_PAT}}
-
-      - name: Notify template repo to update submodule
-        if: github.event_name == 'release' && github.repository == 'SMPTE/html-pub'
-        env:
-          GH_TOKEN: ${{ secrets.TEMPLATE_REPO_PAT }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
-        run: |
-          gh api repos/SMPTE/html-pub-template/dispatches \
-            --method POST \
-            --field event_type=tooling-release \
-            --field "client_payload[tag]=${TAG_NAME}" \
-            --field "client_payload[sha]=${GITHUB_SHA}"
+    # html-pub references its own reusable workflow locally (no @ref).
+    # Document repos reference it as
+    #   SMPTE/html-pub/.github/workflows/build-reusable.yml@<ref>
+    uses: ./.github/workflows/build-reusable.yml
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: true
@@ -42,7 +42,7 @@ jobs:
         run: CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD); for i in `git branch -a | grep remote | grep -v "remotes/pull" | grep -v HEAD | grep -v ${CUR_BRANCH}`; do git branch --track ${i#remotes/origin/} $i; done
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.AWS_ROLE }}
           aws-region: ${{ env.AWS_REGION }}

--- a/doc/main.html
+++ b/doc/main.html
@@ -14,7 +14,7 @@
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->
   <meta itemprop="pubSuiteTitle" content="HTML Pub">
-  <meta itemprop="pubDateTime" content="2026-06-02">
+  <meta itemprop="pubDateTime" content="2026-06-12">
   <!-- <meta itemprop="pubRevisionOf" content="SMPTE ST XXXX-Y:ZZZZ"> -->
   <title>Tooling and documentation for HTML documents</title>
 </head>

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -99,7 +99,7 @@ runs:
         github-token: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Add review links to the pull request
-      uses: marocchino/sticky-pull-request-comment@v2
+      uses: marocchino/sticky-pull-request-comment@v3
       if: github.event_name == 'pull_request' && steps.finder
       with:
         number: ${{ steps.finder.outputs.pr }}

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -19,10 +19,6 @@ runs:
   using: "composite"
   steps:
 
-    - name: Confirm that the right workflow is active
-      shell: bash
-      run: cmp ${GITHUB_ACTION_PATH}/../.github/workflows/main.yml .github/workflows/main.yml
-
     - name: Install vnu
       shell: bash
       run: sudo pip install html5validator==0.4.2


### PR DESCRIPTION
## Summary

Replaces #346. Moves the per-repo build workflow into a single central **reusable workflow** in `html-pub` and folds the "official tooling" enforcement from #346 into it. Each document repo's `main.yml` becomes a thin stub, so future Action/Node bumps and pipeline changes happen **once here** instead of being copy-pasted (and `cmp`-locked) across ~70 repos.

Originally prompted by the GitHub **Node 20 → 24 deprecation** (forced 16 Jun 2026, removed 16 Sep 2026), which flagged `actions/checkout@v3` and `aws-actions/configure-aws-credentials@v1-node16`.

## Replaces #346

#346 ("Enforce official Tooling") kept the duplicated `main.yml` plus a `diff`/`cmp` match check. This supersedes it:

- **Keeps** the submodule provenance + currency enforcement (the valuable part).
- **Drops** the `diff`/`cmp` on `main.yml` — obsolete once `main.yml` is a stub (nothing to compare; it would false-fail).
- **Relocates** enforcement into `build-reusable.yml` (rides the pipeline ref → always current) instead of `action.yml` (submodule-pinned → its checks were only as fresh as the submodule being checked).

Closes #346 in favor of this.

## What changed (html-pub)

- **NEW `.github/workflows/build-reusable.yml`** — `on: workflow_call`, holds the real pipeline:
  - `actions/checkout@v5`, `aws-actions/configure-aws-credentials@v6` (Node 24 clean)
  - existing build/deploy steps unchanged (`./tooling/workflows`, `./workflows`, release notify)
  - **`Enforce official tooling`** step (skipped in `html-pub` itself):
    - **Provenance (always):** `tooling` URL in `.gitmodules` must equal `https://github.com/SMPTE/html-pub.git` — blocks forks.
    - **Currency (always — a build only happens when someone edits the doc, so editors must be current):** recorded submodule SHA must equal latest official `main`, else fail with copy-paste bump instructions.
    - **`OVERRIDE_SUBMODULE_SHA` / `OVERRIDE_SUBMODULE_REF`** inputs — sanctioned escape hatch (mismatch warns instead of failing) for testing or rebuilding an old release.
- **`.github/workflows/main.yml`** → thin stub calling the reusable workflow locally (`uses: ./.github/workflows/build-reusable.yml`).
- **`workflows/action.yml`**:
  - removed the `cmp` "Confirm that the right workflow is active" step (obsolete; false-fails against stubs).
  - bumped `marocchino/sticky-pull-request-comment@v2 → v3` (last Node 20 action surfaced in CI).

Residual: `jwalton/gh-find-current-pr@v1` is still Node 20 — no Node 24 release exists yet, it isn't surfaced as a warning, and it will force-migrate on 16 Jun. Bump when upstream ships one.

## How it works

- Document repo `main.yml` = thin stub: triggers + `permissions` + `uses: SMPTE/html-pub/.github/workflows/build-reusable.yml@<ref>` + `secrets: inherit`.
- The reusable workflow checks out the caller with `submodules: true`; `uses: ./tooling/workflows` resolves against the caller's checked-out submodule, so **build/validation code stays pinned by each repo's submodule SHA** (reproducibility preserved).
- Two independent version knobs, both zero per-repo maintenance for pipeline changes: the stub `@ref` (pipeline) and the submodule SHA (build code).

## Testing — validated on SMPTE/tst123-4-private#2

All three enforcement paths verified on a real consumer repo (stub → `build-reusable.yml@feature/bump-node-GH`):

1. **Happy path** (override active) → ✅ green: `Recorded == Target`, "Official tooling confirmed", full build/deploy ran. https://github.com/SMPTE/tst123-4-private/actions/runs/27441610569
2. **Currency failure** (no override, submodule behind `main`) → ❌ fails with the bump message. https://github.com/SMPTE/tst123-4-private/actions/runs/27441392891
3. **Fork rejection** (`.gitmodules` pointed at `SteveLLamb/html-pub`) → ❌ fails the URL check before any submodule code runs. https://github.com/SMPTE/tst123-4-private/actions/runs/27441703680

Also confirmed the original Node 20 warnings (checkout, aws-creds, sticky-comment) are gone.

## Rollout — every repo that uses the `tooling` submodule

After this merges to `html-pub` `main`:

1. **Switch the pipeline ref to a stable one** — use `@main` (auto-current) or a release tag in stubs, not the feature branch.
2. **Replace each repo's `.github/workflows/main.yml`** with the stub:

   ```yaml
   name: Build SMPTE document

   on:
     push:
     pull_request:
     release:
       types: [published]

   jobs:
     build:
       permissions:
         id-token: write
         contents: write
         pull-requests: write
       uses: SMPTE/html-pub/.github/workflows/build-reusable.yml@main
       secrets: inherit
   ```

3. **Ensure the `tooling` submodule** uses the official URL and is bumped to latest `main` (enforcement requires it at edit time).
4. **No `with: OVERRIDE_*`** in production stubs — that block is testing-only; omitting it enforces latest `main`.
5. **Update `html-pub-template`** so new repos are born with the stub.
6. (Optional) `update-tooling-submodule.yml` still uses `actions/checkout@v3` (warning-only, not `cmp`-guarded) — bump to `@v5` when convenient.

Mechanical and scriptable across the ~69 existing repos; the stub never needs editing again for future pipeline/Action/Node bumps.