### PR TITLE
Issue/0430 80 col width

### DIFF
--- a/css/smpte.css
+++ b/css/smpte.css
@@ -422,7 +422,7 @@ td.top-cell    { vertical-align: top; }
  table.col-6-xwide tr td:nth-child(6), table.col-6-xwide tr th:nth-child(6),
  table.col-7-xwide tr td:nth-child(7), table.col-7-xwide tr th:nth-child(7),
  table.col-8-xwide tr td:nth-child(8), table.col-8-xwide tr th:nth-child(8) {
-   min-width: 80ch;
+   min-width: 40rem;
  }
 
  /* cell width utilities */
@@ -444,7 +444,7 @@ th.col-wide, td.col-wide {
 }
 
 th.col-xwide, td.col-xwide {
-  min-width: 80ch;
+  min-width: 40rem;
 }
 
 table > caption {

--- a/css/smpte.css
+++ b/css/smpte.css
@@ -412,6 +412,19 @@ td.top-cell    { vertical-align: top; }
    width: 20rem;
  }
 
+/* xwide (fits an 80-character listing) */
+
+ table.col-1-xwide tr td:nth-child(1), table.col-1-xwide tr th:nth-child(1),
+ table.col-2-xwide tr td:nth-child(2), table.col-2-xwide tr th:nth-child(2),
+ table.col-3-xwide tr td:nth-child(3), table.col-3-xwide tr th:nth-child(3),
+ table.col-4-xwide tr td:nth-child(4), table.col-4-xwide tr th:nth-child(4),
+ table.col-5-xwide tr td:nth-child(5), table.col-5-xwide tr th:nth-child(5),
+ table.col-6-xwide tr td:nth-child(6), table.col-6-xwide tr th:nth-child(6),
+ table.col-7-xwide tr td:nth-child(7), table.col-7-xwide tr th:nth-child(7),
+ table.col-8-xwide tr td:nth-child(8), table.col-8-xwide tr th:nth-child(8) {
+   min-width: 80ch;
+ }
+
  /* cell width utilities */
 
 th.col-xsmall, td.col-xsmall {
@@ -428,6 +441,10 @@ th.col-medium, td.col-medium {
 
 th.col-wide, td.col-wide {
   width: 20rem;
+}
+
+th.col-xwide, td.col-xwide {
+  min-width: 80ch;
 }
 
 table > caption {

--- a/css/smpte.css
+++ b/css/smpte.css
@@ -422,7 +422,7 @@ td.top-cell    { vertical-align: top; }
  table.col-6-xwide tr td:nth-child(6), table.col-6-xwide tr th:nth-child(6),
  table.col-7-xwide tr td:nth-child(7), table.col-7-xwide tr th:nth-child(7),
  table.col-8-xwide tr td:nth-child(8), table.col-8-xwide tr th:nth-child(8) {
-   min-width: 40rem;
+   min-width: 35rem;
  }
 
  /* cell width utilities */
@@ -444,7 +444,7 @@ th.col-wide, td.col-wide {
 }
 
 th.col-xwide, td.col-xwide {
-  min-width: 80ch;
+  min-width: 35rem;
 }
 
 table > caption {

--- a/css/smpte.css
+++ b/css/smpte.css
@@ -444,7 +444,7 @@ th.col-wide, td.col-wide {
 }
 
 th.col-xwide, td.col-xwide {
-  min-width: 40rem;
+  min-width: 80ch;
 }
 
 table > caption {

--- a/doc/main.html
+++ b/doc/main.html
@@ -1536,14 +1536,16 @@ This is an &lt;code&gt;element&lt;/code&gt; that is rendered with the &lt;code&g
           <dt><code>col-xsmall</code>;</dt>
           <dt><code>col-small</code>;</dt>
           <dt><code>col-medium</code>;</dt>
-          <dt><code>col-wide</code></dt>
-          <dd>Applied to <code>th</code> or <code>td</code> elements to suggest a relative column width for that cell. These classes provide extra-narrow, narrow, medium, or wide column layouts without using inline <code>style</code> attributes. See <a href="#sec-table-width-nowrap-cell"></a></dd>
+          <dt><code>col-wide</code>;</dt>
+          <dt><code>col-xwide</code></dt>
+          <dd>Applied to <code>th</code> or <code>td</code> elements to suggest a relative column width for that cell. These classes provide extra-narrow, narrow, medium, wide, or extra-wide column layouts without using inline <code>style</code> attributes. <code>col-xwide</code> is sized to fit an 80-character listing. See <a href="#sec-table-width-nowrap-cell"></a></dd>
 
           <dt><code>col-1-xsmall</code> through <code>col-8-xsmall</code>;</dt>
           <dt><code>col-1-small</code> through <code>col-8-small</code>;</dt>
           <dt><code>col-1-medium</code> through <code>col-8-medium</code>;</dt>
-          <dt><code>col-1-wide</code> through <code>col-8-wide</code></dt>
-          <dd>Applied to a <code>table</code> element to suggest relative widths for specific columns. See <a href="#sec-table-width-nowrap-column"></a></dd>
+          <dt><code>col-1-wide</code> through <code>col-8-wide</code>;</dt>
+          <dt><code>col-1-xwide</code> through <code>col-8-xwide</code></dt>
+          <dd>Applied to a <code>table</code> element to suggest relative widths for specific columns. The <code>col-1-xwide</code> through <code>col-8-xwide</code> classes are sized to fit an 80-character listing. See <a href="#sec-table-width-nowrap-column"></a></dd>
 
           <dt><code>col-1-center</code> through <code>col-8-center</code>;</dt>
           <dt><code>col-1-right</code> through <code>col-8-right</code>;</dt>

--- a/doc/main.html
+++ b/doc/main.html
@@ -14,7 +14,7 @@
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->
   <meta itemprop="pubSuiteTitle" content="HTML Pub">
-  <meta itemprop="pubDateTime" content="2026-06-12">
+  <meta itemprop="pubDateTime" content="2026-06-23">
   <!-- <meta itemprop="pubRevisionOf" content="SMPTE ST XXXX-Y:ZZZZ"> -->
   <title>Tooling and documentation for HTML documents</title>
 </head>


### PR DESCRIPTION
Both new `xwide` blocks now `min-width: 35rem`— font-independent, consistent with the rem scale, and sized for ~80 monospace columns at the 0.8rem code font. Issue wording ("sized to fit an 80-character listing") still holds.

Documentation for new `col` width added, closes #430 