### PR TITLE
Issues/0432 - Harden release gating: resilient redlines, visible errors, draft pruning, docs

### DIFF
--- a/doc/main.html
+++ b/doc/main.html
@@ -14,7 +14,7 @@
   <meta itemprop="pubConfidential" content="no">
   <!--< meta itemprop="pubTC" content="XX"> -->
   <meta itemprop="pubSuiteTitle" content="HTML Pub">
-  <meta itemprop="pubDateTime" content="2026-06-23">
+  <meta itemprop="pubDateTime" content="2026-06-30">
   <!-- <meta itemprop="pubRevisionOf" content="SMPTE ST XXXX-Y:ZZZZ"> -->
   <title>Tooling and documentation for HTML documents</title>
 </head>

--- a/doc/main.html
+++ b/doc/main.html
@@ -2718,7 +2718,8 @@ ERROR: "validate:html" exited with 5.
 
     <section id="sec-release-trigger">
       <h3>Trigger and auto-draft</h3>
-      <p>Whenever the state of the document changes to <code>&lt;meta itemprop="pubState" content="pub" /&gt;</code> on the <code>main</code> branch, the tooling automatically creates a <em>draft</em> release in the GitHub repo. A user with appropriate permissions reviews and publishes the draft to finalize the release and trigger production of the associated artifacts.</p>
+      <p>Whenever the state of the document changes to <code>&lt;meta itemprop="pubState" content="pub" /&gt;</code> on the <code>main</code> branch, the tooling automatically creates a <em>draft</em> release in the GitHub repo. The draft is created only after a successful build of the merged state, so releases never originate from a failing build. Any earlier draft for the same tag is replaced so drafts do not accumulate. A user with appropriate permissions reviews and publishes the draft to finalize the release and trigger production of the associated artifacts.</p>
+      <p class="note">Releases shall be published from the auto-created draft. Creating or publishing a release manually on an arbitrary commit is not supported: redline generation and document state are derived from the release tags, so a release made on a commit that does not build cleanly will not produce a usable redline reference (subsequent builds warn and skip that redline).</p>
     </section>
 
     <section id="sec-release-naming">
@@ -2739,6 +2740,7 @@ ERROR: "validate:html" exited with 5.
         <li>In the repository on GitHub, navigate to the <strong>Releases</strong> page (<code>https://github.com/SMPTE/{repo}/releases</code>).</li>
         <li>Open the draft release whose name matches the expected <code>YYYYMMDD-pubStage</code> tag for the merged document state.</li>
         <li>Click <strong>Edit</strong>, review the auto-generated release notes, and confirm that the target commit corresponds to the merge that produced the new state.</li>
+        <li>Tick <strong>Set as the latest release</strong>; do not use the <strong>pre-release</strong> label. Redline generation and document state are driven by the <code>pub</code> and stage tags and depend on the most recent release being marked as the latest release.</li>
         <li>Click <strong>Publish release</strong>.</li>
       </ol>
     </section>

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -186,25 +186,37 @@ async function build(buildPaths, baseRef, lastEdRef, lastReleaseRef, docMetadata
     child_process.execSync(`git fetch --tags`);
   }
 
-  /* generate redline against most recent published edition, if requested */
+  /* generate redline against most recent published edition, if requested.
+     Non-critical historical artifact: a bad/old reference tag that no longer
+     renders must NOT fail the build — warn and skip instead. */
 
   if (lastEdRef !== null) {
 
     console.log(`Generating a redline against the latest published edition tag: ${lastEdRef}.`);
 
-    await generateRedline(buildPaths, lastEdRef, buildPaths.pubRedLineRefPath, buildPaths.pubRedlinePath);
-    generatedFiles.pubRedline = buildPaths.pubRedlineName;
+    try {
+      await generateRedline(buildPaths, lastEdRef, buildPaths.pubRedLineRefPath, buildPaths.pubRedlinePath);
+      generatedFiles.pubRedline = buildPaths.pubRedlineName;
+    } catch (e) {
+      console.warn(`::warning::Skipping published-edition redline against ${lastEdRef} (reference failed to render): ${e.message}`);
+    }
 
   }
 
-  /* generate redline against most recent release tag, if requested */
+  /* generate redline against most recent release tag, if requested.
+     Non-critical historical artifact: a bad/old reference tag that no longer
+     renders must NOT fail the build — warn and skip instead. */
 
   if (lastReleaseRef !== null) {
 
     console.log(`Generating a redline against the latest release tag: ${lastReleaseRef}.`);
 
-    await generateRedline(buildPaths, lastReleaseRef, buildPaths.releaseRedLineRefPath, buildPaths.releaseRedlinePath);
-    generatedFiles.releaseRedline = buildPaths.releaseRedlineName;
+    try {
+      await generateRedline(buildPaths, lastReleaseRef, buildPaths.releaseRedLineRefPath, buildPaths.releaseRedlinePath);
+      generatedFiles.releaseRedline = buildPaths.releaseRedlineName;
+    } catch (e) {
+      console.warn(`::warning::Skipping release redline against ${lastReleaseRef} (reference failed to render): ${e.message}`);
+    }
 
   }
 
@@ -491,6 +503,14 @@ async function render(docPath) {
   try {
 
     const page = await browser.newPage();
+
+    /* surface in-page errors in the build log; otherwise they are only visible
+       in the browser console and the build just reports "Page has errors". */
+    page.on("pageerror", err => console.error(`  [page error] ${err.message}`));
+    page.on("console", msg => {
+      if (msg.type() === "error")
+        console.error(`  [page console] ${msg.text()}`);
+    });
 
     const pageURL = "file://" + path.resolve(docPath) + (commitHash ? "?buildHash=" + commitHash : "");
 

--- a/workflows/action.yml
+++ b/workflows/action.yml
@@ -80,6 +80,20 @@ runs:
             exit 1
           fi
         fi
+
+        # Prune any stale DRAFT releases for this tag before creating a new one.
+        # Drafts do not create tags, so the tag check above cannot catch them and
+        # they would otherwise accumulate on every push to main. Only drafts are
+        # deleted here; published releases are never touched.
+        for id in $(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+                      --jq ".[] | select(.tag_name==\"${FINAL_TAG}\" and .draft==true) | .id"); do
+          echo "Deleting stale draft release ${id} for tag ${FINAL_TAG}."
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${id}" >/dev/null
+        done
+
+        # This step runs only after the build step above has succeeded (a failed
+        # build aborts the composite action), so drafts are never auto-created
+        # from a failing build.
         gh release create "$FINAL_TAG" --draft --title "$FINAL_TAG" --target "$GITHUB_SHA" --generate-notes
 
         # If this draft will be a PCD release (CD/pub/no), append a fill-in template


### PR DESCRIPTION
## What

- **build.mjs** — Edition/release redlines now warn and skip when a reference tag fails to render, instead of failing the whole build. A premature or non-building release tag can no longer wedge every build. (PR-base redline stays strict.)
- **build.mjs** — Forward page `pageerror`/console errors to the build log, so render failures show the real cause instead of just `Page has errors`.
- **action.yml** — Prune prior *draft* releases for the same tag before creating a new draft (published releases untouched), so auto-drafts stop piling up. Auto-draft already runs only after a successful build.
- **doc/main.html** — C.5: publish with **Set as the latest release** (not pre-release) (#425). Auto-draft annex: releases come from the auto-created draft, not a manual publish on an arbitrary commit.

## Why

Surfaced on `st2094-50-private`: a release published on a never-green commit wedged every subsequent build at the new release-redline step, with an opaque `Page has errors`. These changes make the redline non-fatal, the failure visible, and draft clutter self-cleaning.

Closes #432 and closes #425 